### PR TITLE
Runs WebIO.setup() using Requires.jl

### DIFF
--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -3,6 +3,7 @@ __precompile__()
 module WebIO
 
 using Observables
+using Requires
 
 include("util.jl")
 include("node.jl")
@@ -26,6 +27,7 @@ render(x::String) = render(Text(x))
 
 function render_inline end
 
+const renderable_types = Type[]
 """
     WebIO.register_renderable(MyType::Type)
 
@@ -33,7 +35,26 @@ Registers that a WebIO.render method is available for instances of `MyType`.
 Allows WebIO to hook into the display machinery of backends such as Atom and
 IJulia to display the WebIO rendered version of the type as appropriate.
 """
-function register_renderable end
+function register_renderable(T)
+    # When a provider is initialised, a new method for this function will be
+    # created for T::Type, outspecialising this one. Until then  we store these
+    # types so we can register them when the provider is setup.
+    println("register_renderable(Any) called")
+    if T isa Type
+        push!(renderable_types, T)
+        return true
+    else
+        ArgumentError("register_renderable should only be called with a Type. Was called with $T which is a $(typeof(T))")
+    end
+end
+
+"""
+Called after a provider is setup
+"""
+function re_register_renderables()
+    foreach(T->Base.invokelatest(register_renderable, T), renderable_types)
+end
+
 function register_renderable_common(T::Type)
     Base.show(io::IO, m::MIME"text/html", x::T) =
         Base.show(io, m, WebIO.render(x))
@@ -43,21 +64,19 @@ function setup_provider(name)
     include(joinpath(dirname(@__FILE__), "providers", "$(name)_setup.jl"))
 end
 
-const butdoesitwork = Ref(false)
+const provider_initialised = Ref(false)
 
-function setup()
-    if isdefined(Main, :IJulia)
-        setup_provider("ijulia")
-    elseif isdefined(Main, :Juno)
-        setup_provider("atom")
-    elseif isdefined(Main, :Blink)
-        setup_provider("blink")
-    elseif isdefined(Main, :Mux)
-        setup_provider("mux")
-    else
-        return
-    end
-    butdoesitwork[] = true
+function setup(provider)
+    println("WebIO: setting up $provider")
+    setup_provider(provider)
+    provider_initialised[] = true
+    re_register_renderables()
 end
+
+# TODO check Juno since Blink might get loaded after/before?
+@require Mux eval(Main, :(WebIO.setup("mux")))
+@require Blink eval(Main, :(WebIO.setup("blink")))
+@require Juno eval(Main, :(WebIO.setup("atom")))
+@require IJulia eval(Main, :(WebIO.setup("ijulia")))
 
 end # module

--- a/src/providers/atom_setup.jl
+++ b/src/providers/atom_setup.jl
@@ -1,8 +1,6 @@
 using Juno
 using WebIO
 
-setup_provider("blink")
-
 function get_page(opts::Dict=Dict())
     Juno.isactive() ? Juno.Atom.blinkplot() : Window(opts).content
 end


### PR DESCRIPTION
WebIO.setup() no longer explicitly required to be called by the user.

N.b. this is a PR against my other PR 😄 - just wanted to see if I can change the branch I'm comparing against after you merge the other one.