### PR TITLE
Css load fix

### DIFF
--- a/assets/basics/node.js
+++ b/assets/basics/node.js
@@ -206,7 +206,7 @@ function doImports(imports) {
                     promises.push(SystemJS.import(imp.url));
                     break;
                 case "css":
-                    var cssId = location.pathname.split( "/" ).join("-");
+                    var cssId = imp.url.split( "/" ).join("-");
                     if (!document.getElementById(cssId))
                     {
                         var head  = document.getElementsByTagName('head')[0];

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -10,7 +10,7 @@ function cssparse(s)
     p = match(r"\[[^\]]+\]", s)
     if p != nothing
         m = strip(p.match, ['[',']'])
-        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*")...), split(m, r",\s*")))
+        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*", limit=2)...), split(m, r",\s*")))
     end
     isempty(classes) || (props[:className] = map(trimfirst, classes))
     tagm = match(r"^[^\.#\[\]]+", s)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -10,7 +10,7 @@ function cssparse(s)
     p = match(r"\[[^\]]+\]", s)
     if p != nothing
         m = strip(p.match, ['[',']'])
-        props[:attributes] = Dict(map(x->Pair(split(x,"=")...), split(m, ",")))
+        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*")...), split(m, r",\s*")))
     end
     isempty(classes) || (props[:className] = map(trimfirst, classes))
     tagm = match(r"^[^\.#\[\]]+", s)
@@ -29,10 +29,13 @@ end
 """
     dom"div.<class>#<id>[<prop>=<value>,...]"(x...; kw...)
 """
-macro dom_str(str)
-    tagstr, props = cssparse(str)
-    tag = Symbol(tagstr)
-    makedom(tag, props)
+macro dom_str(sraw)
+    str = parse(string('"', sraw, '"'))
+    quote
+        tagstr, props = WebIO.cssparse($str)
+        tag = Symbol(tagstr)
+        WebIO.makedom(tag, props)
+    end |> esc
 end
 
 # copied from Blink.jl by Mike Innes
@@ -245,4 +248,3 @@ end
 
 macro new(x) esc(Expr(:new, x)) end
 macro var(x) esc(Expr(:var, x)) end
-


### PR DESCRIPTION
Just the final commit is relevant, the others are in #25 which should be merged first

This section of the code avoids loading css files twice if they have already been loaded.
`location.pathname` is the current browser url, `imp.url` is the url of the css file

Before this you couldn't load more than one css file - as `location.pathname` stays the same on both imports. This fixes it. 