### PR TITLE
Fix JSONification of interpolated `@js` function code 

### DIFF
--- a/assets/basics/node.js
+++ b/assets/basics/node.js
@@ -206,7 +206,7 @@ function doImports(imports) {
                     promises.push(SystemJS.import(imp.url));
                     break;
                 case "css":
-                    var cssId = location.pathname.split( "/" ).join("-");
+                    var cssId = imp.url.split( "/" ).join("-");
                     if (!document.getElementById(cssId))
                     {
                         var head  = document.getElementsByTagName('head')[0];

--- a/src/node.jl
+++ b/src/node.jl
@@ -114,7 +114,7 @@ function Base.show(io::IO, m::MIME"text/html", x::Node)
     id = newid("node")
     write(io, """<div id='$id'></div>
                  <script>WebIO.mount('$id', '#$id',""")
-    JSON.print(io, x)
+    jsexpr(io, x)
     write(io, ")</script>")
 end
 

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -10,7 +10,7 @@ function cssparse(s)
     p = match(r"\[[^\]]+\]", s)
     if p != nothing
         m = strip(p.match, ['[',']'])
-        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*")...), split(m, r",\s*")))
+        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*", limit=2)...), split(m, r",\s*")))
     end
     isempty(classes) || (props[:className] = map(trimfirst, classes))
     tagm = match(r"^[^\.#\[\]]+", s)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -10,7 +10,7 @@ function cssparse(s)
     p = match(r"\[[^\]]+\]", s)
     if p != nothing
         m = strip(p.match, ['[',']'])
-        props[:attributes] = Dict(map(x->Pair(split(x,"=")...), split(m, ",")))
+        props[:attributes] = Dict(map(x->Pair(split(x,r"\s*=\s*")...), split(m, r",\s*")))
     end
     isempty(classes) || (props[:className] = map(trimfirst, classes))
     tagm = match(r"^[^\.#\[\]]+", s)
@@ -29,10 +29,13 @@ end
 """
     dom"div.<class>#<id>[<prop>=<value>,...]"(x...; kw...)
 """
-macro dom_str(str)
-    tagstr, props = cssparse(str)
-    tag = Symbol(tagstr)
-    makedom(tag, props)
+macro dom_str(sraw)
+    str = parse(string('"', sraw, '"'))
+    quote
+        tagstr, props = WebIO.cssparse($str)
+        tag = Symbol(tagstr)
+        WebIO.makedom(tag, props)
+    end |> esc
 end
 
 # copied from Blink.jl by Mike Innes
@@ -245,4 +248,3 @@ end
 
 macro new(x) esc(Expr(:new, x)) end
 macro var(x) esc(Expr(:var, x)) end
-


### PR DESCRIPTION
(This PR is only for the last commit, merge #25 then #26 first)

Previously, interpolated functions were generally in double quotes so they weren't `eval`ed correctly. This meant you couldn't define say Dicts with callback functions as values to include into later code.

Example:
```
using WebIO
jsobj = Dict(:hi=>@js function() hi end)
jscode = @js function()
    $jsobj
end
jscode.s |> println
```
Before: `(function (){return {"hi":"(function (){ alert("hi") })"}})`
After:    `(function (){return {"hi":(function (){ alert("hi") })}})`

Note the double quotes around the nested "hi" function.

edit: Also has a small fix for named functions without arguments