### PR TITLE
Multi widget display and event and command handlers updated

### DIFF
--- a/src/node.jl
+++ b/src/node.jl
@@ -110,8 +110,12 @@ function JSON.lower(n::Node)
     )
 end
 
+# Dict to store callbacks when displaying a Node
+const showcbs = Dict{Node, Function}()
+
 function Base.show(io::IO, m::MIME"text/html", x::Node)
     id = newid("node")
+    x in keys(showcbs) && (x = showcbs[x](io, id))
     write(io, """<div id='$id'></div>
                  <script>WebIO.mount('$id', '#$id',""")
     jsexpr(io, x)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -141,7 +141,7 @@ function jsexpr(io, o::Observable)
         error("No context associated with observer being interpolated")
     end
     _ctx, name = observ_id_dict[o]
-    _ctx.value === nothing && error("Widget of the observable no more exists.")
+    _ctx.value === nothing && error("Widget of the observable doesn't exist anymore.")
     ctx = _ctx.value
 
     obsobj = Dict("type" => "observable",
@@ -252,6 +252,7 @@ function jsexpr(io, x::Expr)
         a_.b_ | a_.(b_) => jsexpr_joined(io, [a, b], ".")
         (a_[] = val_) => obs_set_expr(io, a, val)
         (a_ = b_) => jsexpr_joined(io, [a, b], "=")
+        (a_ += b_) => jsexpr_joined(io, [a, b], "+=")
         (a_ && b_) => jsexpr_joined(io, [a, b], "&&")
         (a_ || b_) => jsexpr_joined(io, [a, b], "||")
         $(Expr(:if, :__)) => if_expr(io, x.args)

--- a/src/widget.jl
+++ b/src/widget.jl
@@ -150,7 +150,7 @@ function after(ctx::Widget, promise_name, expr)
     @evaljs ctx begin
         @var widget = this;
         this.promises[$promise_name].
-            then(val -> $expr.call(widget, val))
+            then(val -> $expr.apply(widget, val))
     end
 end
 
@@ -188,6 +188,14 @@ end
 
 function onjs(ctx, cmd, f)
     push!(Base.@get!(ctx.jshandlers, cmd, []), f)
+end
+
+function offjs(ctx, cmd, f)
+    if f in get(ctx.jshandlers, cmd, [])
+        cmds = ctx.jshandlers[cmd]
+        deleteat!(cmds, findin(cmds, f))
+    end
+    nothing
 end
 
 # Backedge denotes that the function updates the


### PR DESCRIPTION
Enables registering a callback in `show(n::Node, ...)`, which is a way for a single Widget to be displayed multiple times (there will be multiple js contexts associated with the same Julia Widget).

Also
* `after` now called with `apply` not `call`, meaning, for example, each dependency for ondependencies, is now passed as a separate argument, rather than the first argument holding an array.
* command and event handlers updated for new JSEvalSerializer JSON regime
* offjs method added (untested/unused in the end)
* Syntax for `+=` added for js macros