### PR TITLE
Stops `show`'s rampant piracy and fixes error in unencode_scripts

### DIFF
--- a/assets/basics/webio.js
+++ b/assets/basics/webio.js
@@ -172,6 +172,7 @@ function sendNotSetUp()
 
 //unescape closing script tags which cause problems in html documents
 function unencode_scripts(htmlstr){
+    if (typeof htmlstr !== "string") return htmlstr;
     return htmlstr.replace(new RegExp("</_script>", "g"), "</scr"+"ipt>")
 }
 

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -64,12 +64,12 @@ function setup_provider(name)
     include(joinpath(dirname(@__FILE__), "providers", "$(name)_setup.jl"))
 end
 
-const provider_initialised = Ref(false)
+const providers_initialised = Set{String}()
 
 function setup(provider)
     println("WebIO: setting up $provider")
     setup_provider(provider)
-    provider_initialised[] = true
+    push!(providers_initialised, provider)
     re_register_renderables()
 end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -168,7 +168,7 @@ function showindent(io, level)
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", el)
+function Base.show(io::IO, ::MIME"text/plain", el::Node)
     _show(io, el)
 end
 


### PR DESCRIPTION
Also, adds recording of which backend providers have been initialised