### PR TITLE
Default rendering for all types and Observable Array Fixes

### DIFF
--- a/assets/basics/node.js
+++ b/assets/basics/node.js
@@ -303,8 +303,9 @@ WebIO.NodeTypes = {
 
 WebIO.CommandSets = {
     Basics: {
+        // XXX security!?
         eval: function (code) {
-            var f = new Function(code); // XXX security!?
+            var f = new Function(code);
             f.call(this);
         }
     }

--- a/assets/basics/webio.js
+++ b/assets/basics/webio.js
@@ -1,3 +1,10 @@
+var is_array = require('is-array')
+var arrays_equal = require('array-equal')
+
+function arrays_and_equal(arr1, arr2){
+    return is_array(arr1) && is_array(arr2) && arrays_equal(arr1, arr2)
+}
+
 var contexts = {};
 var obscontexts = {};
 
@@ -110,10 +117,11 @@ function setval(ob, val) {
         var ctx = octxinfo.ctx
         var name = octxinfo.obname // the name of the observable in octx
         var x = ctx.observables[name]
-        if (val === x.value || (val !== val && x.value !== x.value)) {
+        if (val === x.value || arrays_and_equal(val, x.value) ||
+                (val !== val && x.value !== x.value)) {
             // adapted from Vue.js reactiveSetter, avoids calling handlers if value
-            // is unchanged. The second check is for values like NaN, since, e.g.,
-            // NaN !== NaN
+            // is unchanged. The second check is for arrays, since ["a"] !== ["a"].
+            // The third check is for values like NaN, since, e.g., NaN !== NaN
             return
         }
         x.value = val

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,6 +10,8 @@
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.22.0",
+    "array-equal": "^1.0",
+    "is-array": "^1.0.1",
     "systemjs": "^0.20.5",
     "webpack": "^2.2.1"
   }

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -9,56 +9,11 @@ include("util.jl")
 include("node.jl")
 include("syntax.jl")
 include("widget.jl")
+include("render.jl")
 include("connection.jl")
 include("devsetup.jl")
 
 export setup_provider
-
-"""
-    render(x::MyType)
-
-Generic function that defines how a Julia object is rendered. Should return a
-`Node` object.
-"""
-function render end
-render(x::Node) = x
-render(x::Text) = dom"span"(x.content)
-render(x::String) = render(Text(x))
-
-function render_inline end
-
-const renderable_types = Type[]
-"""
-    WebIO.register_renderable(MyType::Type)
-
-Registers that a WebIO.render method is available for instances of `MyType`.
-Allows WebIO to hook into the display machinery of backends such as Atom and
-IJulia to display the WebIO rendered version of the type as appropriate.
-"""
-function register_renderable(T)
-    # When a provider is initialised, a new method for this function will be
-    # created for T::Type, outspecialising this one. Until then  we store these
-    # types so we can register them when the provider is setup.
-    println("register_renderable(Any) called")
-    if T isa Type
-        push!(renderable_types, T)
-        return true
-    else
-        ArgumentError("register_renderable should only be called with a Type. Was called with $T which is a $(typeof(T))")
-    end
-end
-
-"""
-Called after a provider is setup
-"""
-function re_register_renderables()
-    foreach(T->Base.invokelatest(register_renderable, T), renderable_types)
-end
-
-function register_renderable_common(T::Type)
-    Base.show(io::IO, m::MIME"text/html", x::T) =
-        Base.show(io, m, WebIO.render(x))
-end
 
 function setup_provider(name)
     include(joinpath(dirname(@__FILE__), "providers", "$(name)_setup.jl"))

--- a/src/render.jl
+++ b/src/render.jl
@@ -1,0 +1,80 @@
+"""
+    render(x::MyType)
+
+Generic function that defines how a Julia object is rendered. Should return a
+`Node` object.
+"""
+function render end
+render(x::Node) = x
+render(x::Text) = dom"span"(x.content)
+render(x::String) = render(Text(x))
+render(::Void) = ""
+render(x::Any) =
+    dom"div"(; setInnerHtml=richest_html(x))
+
+function render_inline end
+
+const renderable_types = Type[]
+"""
+    `WebIO.register_renderable(MyType::Type)`
+
+Registers that a WebIO.render method is available for instances of `MyType`.
+Allows WebIO to hook into the display machinery of backends such as Atom and
+IJulia to display the WebIO rendered version of the type as appropriate.
+
+Also defines a `Base.show(io::IO, m::MIME"text/html", x::MyType)` as
+`Base.show(io, m, WebIO.render(x))`
+"""
+function register_renderable(T)
+    # When a provider is initialised, a new method for this function will be
+    # created for T::Type, outspecialising this one. Until then  we store these
+    # types so we can register them when the provider is setup.
+    println("register_renderable(Any) called")
+    if T isa Type
+        push!(renderable_types, T)
+        return true
+    else
+        ArgumentError("register_renderable should only be called with a Type. Was called with $T which is a $(typeof(T))")
+    end
+end
+
+"""
+Called after a provider is setup
+"""
+function re_register_renderables()
+    foreach(T->Base.invokelatest(register_renderable, T), renderable_types)
+end
+
+function register_renderable_common(T::Type)
+    Base.show(io::IO, m::MIME"text/html", x::T) =
+        Base.show(io, m, WebIO.render(x))
+end
+
+
+"""
+Generic Conversion to Nodes
+"""
+
+const mime_order = map(MIME, [ "text/html", "text/latex", "image/svg+xml", "image/png", "image/jpeg", "text/markdown", "application/javascript", "text/plain" ])
+
+function richest_mime(val)
+    for mimetype in mime_order
+        mimewritable(mimetype, val) && return mimetype
+    end
+    error("value not writable for any mimetypes")
+end
+
+function richest_html(val)
+    topmime = richest_mime(val)
+    str_repr = stringmime(topmime, val)
+    res = (if topmime == MIME("text/html")
+        str_repr |> WebIO.encode_scripts
+    elseif topmime in map(MIME, ["image/svg+xml", "image/png", "image/jpeg"])
+        "<img src='data:image/png;base64,$str_repr'></img>"
+    elseif topmime == MIME("text/plain")
+        "<span>$str_repr</span>"
+    end)
+    res
+end
+
+richest_html(::Void) = ""


### PR DESCRIPTION
Adds default rendering for all types using richest show. This won't generally be used unless register_renderable(::Type) is called but can come in handy. E.g. InteractNext uses it to display auto-updating Observables

Fixes array valued observable updating. Turns out that in js `["a"] !== ["a"]` - this deals with that in the context of propagating observable updates
