### PR TITLE
Remove JS Message Logging and Fix issue with dots in dom_str props

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ JSON 0.7
 FunctionalCollections
 MacroTools
 Observables
+Requires

--- a/assets/basics/webio.js
+++ b/assets/basics/webio.js
@@ -70,9 +70,7 @@ function dispatch(msg)
         console.warn("invalid message received", msg)
     } else {
         var ctx = contexts[msg.context];
-        console.log(msg)
         var fs = getHandlers(ctx, msg.command);
-        console.log(fs)
         for (var i=0, l=fs.length; i<l; i++) {
             var f = fs[i]
             f.call(ctx, msg.data, false) // false for "not client-side"

--- a/src/render.jl
+++ b/src/render.jl
@@ -6,7 +6,7 @@ Generic function that defines how a Julia object is rendered. Should return a
 """
 function render end
 render(x::Node) = x
-render(x::Text) = dom"span"(x.content)
+render(x::Text) = dom"pre"(x.content)
 render(x::String) = render(Text(x))
 render(::Void) = ""
 render(x::Any) =
@@ -72,7 +72,7 @@ function richest_html(val)
     elseif topmime in map(MIME, ["image/svg+xml", "image/png", "image/jpeg"])
         "<img src='data:image/png;base64,$str_repr'></img>"
     elseif topmime == MIME("text/plain")
-        "<span>$str_repr</span>"
+        "<pre>$str_repr</pre>"
     end)
     res
 end

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -9,8 +9,6 @@ notinstalled && AtomShell.install()
 
 @testset "Blink mocks" begin
 
-    @test WebIO.setup()
-
     # open window and wait for it to initialize
     w = Window(Dict(:show => false))
 
@@ -28,10 +26,10 @@ notinstalled && AtomShell.install()
         @test_throws ErrorException WebIO.@js $ob
 
         ob = Observable{Any}(w, "test", nothing)
-        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"context\":\"testwidget2\",\"type\":\"observable\"}"
+        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"}"
 
-        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"context\":\"testwidget2\",\"type\":\"observable\"})"
-        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"context\":\"testwidget2\",\"type\":\"observable\"},1)"
+        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"})"
+        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"},1)"
     end
 
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -44,7 +44,7 @@ end
               return end) == js"(function (x){x; return })"
     @test @js(x->(1; return x+1)) == js"(function (x){1; return (x+1)})"
     @test @js(function (x) x+1; end) == js"(function (x){return (x+1)})"
-    
+
     @test @js(@new F()) == js"new F()"
     @test @js(@var x=1) == js"var x=1"
 
@@ -66,4 +66,8 @@ end
     @test props(n)[:attributes] == Dict("a" => "b")
     @test props(n)[:className] == ["x", "y"]
     @test props(n)[:id] == "i"
+
+    # dots in props area
+    n = dom"img[src=$im.jpg]"()
+    @test !haskey(props(n), :className)
 end


### PR DESCRIPTION
* removes console.log on every message
* fixes parsing when props have `.`s in them, e.g. dom"img[src=image.jpg]. fixes #34
* adds test for the above
* improves dom_str hygiene (was overwriting tagstr, tag, props in user context)
* fixes Blink test with Observables updates
edit:
* and span changed to pre for Text