### PR TITLE
Rename Widget to Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WebIO provides a simple abstraction for displaying and interacting with content.
 - [Blink](https://github.com/JunoLab/Blink.jl) - An [Electron](http://electron.atom.io/) wrapper you can use to make Desktop apps
 - [Mux](https://github.com/JuliaWeb/Mux.jl) - A web server framework
 
-Widgets once created with WebIO will work on any of these front-ends.
+Scopes once created with WebIO will work on any of these front-ends.
 
 Getting started
 ---------------
@@ -243,14 +243,12 @@ dom"button"("Greet",
 
 Note that `@js` just translates a Julia expression to the equivalent JavaScript, it does not compile the code. The variables and functions you reference in a `@js` expression must be defined in the JavaScript context it will run in (and need not be defined in Julia).
 
-# Widgets
-
 ## Loading JavaScript dependencies
 
-You can load dependencies by creating a Widget object and passing in `imports` argument.
+You can load dependencies by creating a Scope object and passing in `imports` argument.
 
 ```julia
-w = Widget(imports=["//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/p5.js"])
+w = Scope(imports=["//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/p5.js"])
 
 onimport(w, @js function (p5)
     function sketch(s)
@@ -274,10 +272,10 @@ w(dom"div#container"())
 ## Communicating between Julia and JavaScript
 
 ```julia
-w = Widget()
+w = Scope()
 ```
 
-A widget object acts as a container for communication (more details below). To exchange values between JavaScript and Julia, we also need to add `Observable` objects to the widget. This can be done by passing the widget, and an identifier for the observable (as string) and a default value to the `Observable` constructor:
+A scope object acts as a container for communication (more details below). To exchange values between JavaScript and Julia, we also need to add `Observable` objects to the scope. This can be done by passing the scope, and an identifier for the observable (as string) and a default value to the `Observable` constructor:
 
 ```julia
 obs = Observable(w, "rand-value", 0.0)
@@ -293,11 +291,11 @@ This will run `f` on every update to `obs`.
 
 ### Sending values from JavaScript to Julia
 
-Below is a widget which communicates with Julia. Let's run through its construction line-by-line. The following widget contains a button which sends a random number, generated in JavaScript, to Julia. We will print this number on the Julia side.
+Below is a scope which communicates with Julia. Let's run through its construction line-by-line. The following scope contains a button which sends a random number, generated in JavaScript, to Julia. We will print this number on the Julia side.
 
 ```julia
 function random_print_button()
-    w = Widget()
+    w = Scope()
 
     obs = Observable(w, "rand-value", 0.0)
 
@@ -314,9 +312,9 @@ function random_print_button()
 end
 ```
 
-`w` is a Widget object, it acts a scope or context for communication. Every call to `random_print_button` will create a new widget and hence keep the updates contained within it. This allows there to be many instances of the same widget on a page.
+`w` is a Scope object, it acts a scope or context for communication. Every call to `random_print_button` will create a new scope and hence keep the updates contained within it. This allows there to be many instances of the same scope on a page.
 
-An `Observable` is a value that can change over time. `Observable(w, "rand-value", 0.0)` creates an observable by the name "rand-value" associated with widget `w`. `on(f, x)` sets up an event handler such that `f` is called with the value of `x` every time `x` is updated.
+An `Observable` is a value that can change over time. `Observable(w, "rand-value", 0.0)` creates an observable by the name "rand-value" associated with scope `w`. `on(f, x)` sets up an event handler such that `f` is called with the value of `x` every time `x` is updated.
 
 An observable can be updated using the `x[] = value` syntax on Julia. To update the observable from the JavaScript side, you can use the following syntax:
 
@@ -334,14 +332,14 @@ This will return a `JSExpr` which you can use anywhere WebIO expects JavaScript,
 ```
 creates a button UI which updates the `obs` observable with `Math.random()` (executed in JS) on every click.
 
-Notice the last expression actually _calls_ the widget `w` with the contents to display. This causes the contents to be _wrapped_ in `w`'s context. All uses of observables associated with `w` (e.g. `obs`) should be enclosed in the widget `w`.
+Notice the last expression actually _calls_ the scope `w` with the contents to display. This causes the contents to be _wrapped_ in `w`'s context. All uses of observables associated with `w` (e.g. `obs`) should be enclosed in the scope `w`.
 
 ### Sending values from Julia to JavaScript
 
 Here's a clock where the time is formatted and updated every second from Julia. We use the `onjs` handler and mutate the `#clock` DOM element to acheive this.
 
 ```julia
-w = Widget()
+w = Scope()
 obs = Observable(w, "clock-value", "")
 
 timestr() = Dates.format(now(), "HH:MM:SS")
@@ -365,5 +363,5 @@ w(
 )
 ```
 
-The javascript function passed to `onjs` gets the value of the update as the argument. `this` is set to the Widget object. Notice the use of `this.dom.querySelector("#clock")`. `this.dom` contains the rendered DOM of the widget. `querySelector("#<id>")` will look up the element which has the id `<id>`. `clock.textContent = val` will set the text contained in `clock`, the DOM element.
+The javascript function passed to `onjs` gets the value of the update as the argument. `this` is set to the Scope object. Notice the use of `this.dom.querySelector("#clock")`. `this.dom` contains the rendered DOM of the scope. `querySelector("#<id>")` will look up the element which has the id `<id>`. `clock.textContent = val` will set the text contained in `clock`, the DOM element.
 

--- a/assets/webio/node.js
+++ b/assets/webio/node.js
@@ -6,7 +6,7 @@ var EVENT_KEY = 'events';
 var ATTR_KEY = 'attributes';
 var ATTR_NS_KEY = 'attributes_ns';
 
-function applyProps(context, domNode, props)
+function applyProps(scope, domNode, props)
 {
     for (var key in props) {
         var value = props[key];
@@ -18,7 +18,7 @@ function applyProps(context, domNode, props)
                 break;
 
             case EVENT_KEY:
-                applyEvents(domNode, context, value);
+                applyEvents(domNode, scope, value);
                 break;
 
             case ATTR_KEY:
@@ -92,7 +92,7 @@ function applyStyles(domNode, styles)
     }
 }
 
-function applyEvents(domNode, context, events)
+function applyEvents(domNode, scope, events)
 {
     var allHandlers = domNode.webio_handlers || {};
 
@@ -114,7 +114,7 @@ function applyEvents(domNode, context, events)
                     handlerfn.call(domNode, event);
                 });
             }
-            allHandlers[key] = makeEventHandler(context, value);
+            allHandlers[key] = makeEventHandler(scope, value);
             bindHandler(allHandlers[key])
         }
         else
@@ -131,10 +131,10 @@ var defaultEventOptions = {
     preventDefault: false
 }
 
-function makeEventHandler(context, value)
+function makeEventHandler(scope, value)
 {
     if (typeof value == "function") {
-        return makeEventHandler(context, {
+        return makeEventHandler(scope, {
             code: value, options: defaultEventOptions
         })
     }
@@ -151,20 +151,20 @@ function makeEventHandler(context, value)
         }
 
         // http://stackoverflow.com/questions/1271516/executing-anonymous-functions-created-using-javascript-eval
-        f.call(this, event, context); //XXX security!?
+        f.call(this, event, scope); //XXX security!?
     }
 
     eventHandler.options = options;
     return eventHandler;
 }
 
-function appendChildren(context, parentNode, children) {
+function appendChildren(scope, parentNode, children) {
     if (children) {
         for (var nChildren=children.length, i=0; i<nChildren; i++) {
             if (typeof children[i] === "string") {
                 parentNode.appendChild(document.createTextNode(children[i]));
             } else {
-                var child = WebIO.createNode(context, children[i], parentNode);
+                var child = WebIO.createNode(scope, children[i], parentNode);
                 parentNode.appendChild(child);
             }
         }
@@ -174,7 +174,7 @@ function appendChildren(context, parentNode, children) {
 
 var namespaces = {svg: "http://www.w3.org/2000/svg"}
 
-function createDOM(ctx, data, parentNode) {
+function createDOM(scope, data, parentNode) {
 
     var args = data.instanceArgs;
     var dom;
@@ -185,13 +185,13 @@ function createDOM(ctx, data, parentNode) {
         dom = document.createElementNS(ns, args.tag);
     }
 
-    applyProps(ctx, dom, data.props);
-    appendChildren(ctx, dom, data.children)
+    applyProps(scope, dom, data.props);
+    appendChildren(scope, dom, data.children)
 
     return dom;
 }
 
-function doImports(widget, imp) {
+function doImports(scope, imp) {
     // this function must return a promise which resolves to a
     // vector of modules or null values (null values for non-modules)
     switch (imp.type) {
@@ -211,7 +211,7 @@ function doImports(widget, imp) {
             function makePromisClosure(sync_import) {
                 return function (vec) {
                     // vec contains previously resolved modules
-                    var y = doImports(widget, sync_import) // a promise
+                    var y = doImports(scope, sync_import) // a promise
                     var flatten = (sync_import.type == "sync_block" ||
                                    sync_import.type == "async_block")
 
@@ -233,7 +233,7 @@ function doImports(widget, imp) {
             }
             return p;
         case "async_block":
-            var ps = imp.data.map(function(x){return doImports(widget, x)})
+            var ps = imp.data.map(function(x){return doImports(scope, x)})
             return Promise.all(ps).then(function (mods) {
                 var mods2 = []
                 for (var i=0, l=imp.data.length; i<l; i++) {
@@ -252,7 +252,7 @@ function doImports(widget, imp) {
             SystemJS.config(cfg)
             return SystemJS.import(imp.url).then(function (mod) {
                 if (imp.name) {
-                    widget[imp.name] = mod
+                    scope[imp.name] = mod
                 }
                 return mod
             })
@@ -293,43 +293,43 @@ function doImports(widget, imp) {
     }
 }
 
-function createWidget(ctx, data) {
+function createScope(scope, data) {
     var fragment = document.createElement("div");
-    fragment.className = "wio-context";
+    fragment.className = "wio-scope";
 
     // var handlers = data.instanceArgs.handlers;
     var observables = data.instanceArgs.observables;
     var handlers = data.instanceArgs.handlers;
 
-    var subctx = WebIO.makeWidget(data.instanceArgs.id, ctx.data,
-                             ctx.sendCallback, fragment, handlers, observables);
+    var subscope = WebIO.makeScope(data.instanceArgs.id, scope.data,
+                             scope.sendCallback, fragment, handlers, observables);
 
     if (handlers["preDependencies"]) {
         var predepfns = handlers["preDependencies"]
-        predepfns.map(function (f){ f(subctx) })
+        predepfns.map(function (f){ f(subscope) })
     }
 
     var imports = data.instanceArgs.imports;
 
-    var depsPromise = doImports(subctx, imports);
-    subctx.promises.importsLoaded = depsPromise
+    var depsPromise = doImports(subscope, imports);
+    subscope.promises.importsLoaded = depsPromise
 
-    subctx.promises.connected = new Promise(function (accept, reject) {
+    subscope.promises.connected = new Promise(function (accept, reject) {
         WebIO.onConnected(function () {
             // internal message to notify julia
-            WebIO.send(subctx, "_setup_context", {});
-            accept(subctx);
+            WebIO.send(subscope, "_setup_scope", {});
+            accept(subscope);
         })
     })
 
     depsPromise.then(function (deps) {
-        appendChildren(subctx, fragment, data.children);
+        appendChildren(subscope, fragment, data.children);
     })
 
     if (handlers["importsLoaded"]){
         depsPromise.then(function(alldeps){
             var ondepsfns = handlers["importsLoaded"]
-            ondepsfns.map(function (f){ f.apply(subctx, alldeps) })
+            ondepsfns.map(function (f){ f.apply(subscope, alldeps) })
         })
     }
 
@@ -338,7 +338,7 @@ function createWidget(ctx, data) {
 
 var style = document.createElement('style')
 style.type = 'text/css'
-style.innerHTML = '.wio-context { display:inherit; margin:inherit }'
+style.innerHTML = '.wio-scope { display:inherit; margin:inherit }'
 document.getElementsByTagName('head')[0].appendChild(style)
 
 WebIO.NodeTypes = {
@@ -346,8 +346,8 @@ WebIO.NodeTypes = {
         namespaces: namespaces,
         create: createDOM
     },
-    Widget: {
-        create: createWidget
+    Scope: {
+        create: createScope
     }
 }
 

--- a/awkward.md
+++ b/awkward.md
@@ -1,6 +1,3 @@
 - Do we need to use the DOM? Can we just output HTML? We don't have diff-patch so far, and it doens't look like we need it?
-- Widget conflates:
-    - JS loading
-    - Communication context
 - dom"div"() is bad for the eye
 - `@tags div, em, ul, li` may be a good idea to steal from Documenter

--- a/examples/blink_counter.jl
+++ b/examples/blink_counter.jl
@@ -2,7 +2,7 @@ using Blink
 using WebIO
 
 function counter(start=0)
-    w = Widget()
+    w = Scope()
 
     # updates to this update the UI
     count = Observable(w, "count", start)

--- a/examples/mux_counter.jl
+++ b/examples/mux_counter.jl
@@ -2,19 +2,19 @@ using WebIO
 setup_provider("mux")
 
 function counter(count=0)
-    withcontext(Context()) do ctx
-        # ctx is the Context object
+    withcontext(Context()) do scope
+        # scope is the Context object
 
         # handle(context, command_name) - add a handler for a command coming from JavaScript
 
-        handle!(ctx, :change) do d
-            send(ctx, :set_count, count+=d)
+        handle!(scope, :change) do d
+            send(scope, :set_count, count+=d)
         end
 
-        # handlejs(ctx, command_name, function_string) - add a handler for a command coming in from the Julia side
-        # in this case we access the element with the id "count" from ctx.dom, and set its contents to the new count
+        # handlejs(scope, command_name, function_string) - add a handler for a command coming in from the Julia side
+        # in this case we access the element with the id "count" from scope.dom, and set its contents to the new count
 
-        handlejs!(ctx, :set_count, "function (ctx,msg) {ctx.dom.querySelector('#count').textContent = msg}")
+        handlejs!(scope, :set_count, "function (scope,msg) {scope.dom.querySelector('#count').textContent = msg}")
 
         # the btn function defined below takes a label and a change value and creates a button which
         # when clicked, asks julia to change the counter by the given change value by sending the "change" command
@@ -25,7 +25,7 @@ function counter(count=0)
                     # an event handler on Javascript always gets two arguments: the event and the context
                     # event is object passed by JavaScript into the event handler, and context is the context
                     # using which you can talk to julia or access and modify contents of the context (context.dom as seen above)
-                    "click"=>"function (event,ctx) { WebIO.send(ctx, 'change', $change) }"
+                    "click"=>"function (event,scope) { WebIO.send(scope, 'change', $change) }"
                 )
             )
 

--- a/examples/p5.jl
+++ b/examples/p5.jl
@@ -2,8 +2,8 @@ using WebIO
 setup_provider("mux")
 
 function myapp(req)
-    withcontext(Widget()) do ctx
-        adddeps!(ctx, ["//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"])
+    withcontext(Scope()) do scope
+        adddeps!(scope, ["//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.7/p5.js"])
         sketch = @js function (p5)
             @var s = function(p)
                 @var barWidth = 20
@@ -29,7 +29,7 @@ function myapp(req)
             this.dom.querySelector("#p5container").innerText = "";
             @new p5(s, "p5container");
         end
-        ondependencies(ctx, sketch)
+        ondependencies(scope, sketch)
 
         dom"div#p5container"("Loading p5...")
     end

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -8,7 +8,7 @@ using Requires
 include("util.jl")
 include("node.jl")
 include("syntax.jl")
-include("widget.jl")
+include("scope.jl")
 include("render.jl")
 include("connection.jl")
 include("devsetup.jl")

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -22,16 +22,16 @@ end
 function dispatch(conn::AbstractConnection, data)
     # first, check if the message is one of the administrative ones
     cmd = data["command"]
-    ctxid = data["context"]
-    if cmd == "_setup_context"
-        if haskey(contexts, ctxid)
-            ctx = contexts[ctxid]
+    scopeid = data["scope"]
+    if cmd == "_setup_scope"
+        if haskey(scopes, scopeid)
+            scope = scopes[scopeid]
             @async while true
-                msg = take!(ctx.outbox)
+                msg = take!(scope.outbox)
                 send(conn, msg)
             end
         else
-            log(conn, "Client says it has unknown context $ctxid", "warn")
+            log(conn, "Client says it has unknown scope $scopeid", "warn")
         end
     elseif cmd == "_acknowledge_message"
         msgid = data["messageId"]
@@ -45,12 +45,12 @@ function dispatch(conn::AbstractConnection, data)
                 "warn")
         end
     else
-        if !haskey(contexts, ctxid)
-            log(conn, "Message $data received for unknown context $ctxid", "warn")
+        if !haskey(scopes, scopeid)
+            log(conn, "Message $data received for unknown scope $scopeid", "warn")
             return
         end
-        ctx = contexts[ctxid]
-        dispatch(ctx, cmd, data["data"])
+        scope = scopes[scopeid]
+        dispatch(scope, cmd, data["data"])
     end
 end
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -28,8 +28,8 @@ lowerdeps(xs::AbstractArray) = Dict(
 lowerdeps(x::Sync) = Dict("type"=>"sync_block",
                           "data" => map(lowerdeps, x.xs))
 
-function import!(widget, xs)
-    push!(widget.imports, xs)
+function import!(scope, xs)
+    push!(scope.imports, xs)
 end
 
-Base.@deprecate adddeps!(widget, x) import!(widget, x)
+Base.@deprecate adddeps!(scope, x) import!(scope, x)

--- a/src/providers/atom_setup.jl
+++ b/src/providers/atom_setup.jl
@@ -6,10 +6,10 @@ function get_page(opts::Dict=Dict())
 end
 
 media(Node, Media.Graphical)
-Juno.render(::Juno.PlotPane, n::Union{Node, Widget}) =
+Juno.render(::Juno.PlotPane, n::Union{Node, Scope}) =
     (body!(get_page(), n); nothing)
 
-Juno.render(i::Juno.Editor, n::Union{Node, Widget}) =
+Juno.render(i::Juno.Editor, n::Union{Node, Scope}) =
     Juno.render(i, Text("$(n.instanceof) Node with $(n._descendants_count) descendent(s)"))
 
 function WebIO.register_renderable(T::Type)

--- a/src/providers/blink_setup.jl
+++ b/src/providers/blink_setup.jl
@@ -5,7 +5,7 @@ immutable BlinkConnection <: WebIO.AbstractConnection
     page::Page
 end
 
-function Blink.body!(p::Page, x::Union{Node, Widget})
+function Blink.body!(p::Page, x::Union{Node, Scope})
     wait(p)
     loadjs!(p, "/pkg/WebIO/webio/bundle.js")
     loadjs!(p, "/pkg/WebIO/providers/blink_setup.js")
@@ -18,7 +18,7 @@ function Blink.body!(p::Page, x::Union{Node, Widget})
     body!(p, stringmime(MIME"text/html"(), x))
 end
 
-function Blink.body!(p::Window, x::Union{Node, Widget})
+function Blink.body!(p::Window, x::Union{Node, Scope})
     body!(p.content, x)
 end
 

--- a/src/providers/ijulia_setup.jl
+++ b/src/providers/ijulia_setup.jl
@@ -3,10 +3,6 @@ using IJulia.CommManager
 
 using WebIO
 
-function script(f)
-    display(HTML("<script src='/pkg/WebIO/webio/bundle.js'></script>"))
-end
-
 immutable IJuliaConnection <: AbstractConnection
     comm::CommManager.Comm
 end

--- a/src/providers/mux_setup.jl
+++ b/src/providers/mux_setup.jl
@@ -47,7 +47,7 @@ function Base.send(p::WebSockConnection, data)
 end
 
 
-function Mux.Response(o::Node)
+function Mux.Response(o::Union{Node, Scope})
     Mux.Response(
         """
         <!doctype html>

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -148,14 +148,14 @@ end
 
 function jsexpr(io, o::Observable)
     if !haskey(observ_id_dict, o)
-        error("No context associated with observer being interpolated")
+        error("No scope associated with observer being interpolated")
     end
-    _ctx, name = observ_id_dict[o]
-    _ctx.value === nothing && error("Widget of the observable doesn't exist anymore.")
-    ctx = _ctx.value
+    _scope, name = observ_id_dict[o]
+    _scope.value === nothing && error("Scope of the observable doesn't exist anymore.")
+    scope = _scope.value
 
     obsobj = Dict("type" => "observable",
-                  "context" => ctx.id,
+                  "scope" => scope.id,
                   "name" => name,
                   "id" => obsid(o))
 

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -21,15 +21,15 @@ notinstalled && AtomShell.install()
     @test all(x->contains(content, x), substrings)
 
     @testset "observable interpolation" begin
-        w = Widget("testwidget2")
+        w = Scope("testwidget2")
         ob = Observable(0)
         @test_throws ErrorException WebIO.@js $ob
 
         ob = Observable{Any}(w, "test", nothing)
-        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"}"
+        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"}"
 
-        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"})"
-        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"id\":\"ob_03\",\"context\":\"testwidget2\",\"type\":\"observable\"},1)"
+        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"})"
+        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"},1)"
     end
 
 end

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -35,4 +35,4 @@ notinstalled && AtomShell.install()
 end
 
 
-notinstalled && AtomShell.remove()
+notinstalled && AtomShell.uninstall()

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -15,7 +15,7 @@ notinstalled && AtomShell.install()
     body!(w, dom"div"("hello, blink"))
     sleep(5) # wait for it to render.
 
-    substrings = ["<script>WebIO.mount(",
+    substrings = [r"\<unsafe-script.+WebIO.mount\(",
     """{"props":{},"nodeType":"DOM","type":"node","instanceArgs":{"namespace":"html","tag":"div"},"children":["hello, blink"]}"""]
     content = Blink.@js(w, document.body.innerHTML)
     @test all(x->contains(content, x), substrings)
@@ -26,10 +26,10 @@ notinstalled && AtomShell.install()
         @test_throws ErrorException WebIO.@js $ob
 
         ob = Observable{Any}(w, "test", nothing)
-        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"}"
+        @test WebIO.@js($ob) == js"{\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_03\",\"type\":\"observable\"}"
 
-        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"})"
-        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"id\":\"ob_03\",\"scope\":\"testwidget2\",\"type\":\"observable\"},1)"
+        @test WebIO.@js($ob[]) == js"WebIO.getval({\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_03\",\"type\":\"observable\"})"
+        @test WebIO.@js($ob[] = 1) == js"WebIO.setval({\"name\":\"test\",\"scope\":\"testwidget2\",\"id\":\"ob_03\",\"type\":\"observable\"},1)"
     end
 
 end

--- a/test/communication.jl
+++ b/test/communication.jl
@@ -10,9 +10,9 @@ import WebIO: dispatch
 
 @testset "communication" begin
 
-    w = Widget("testctx1")
+    w = Scope("testctx1")
 
-   #@test isa(instanceof(w), Widget)
+   #@test isa(instanceof(w), Scope)
    #@test instanceof(w).id == "testctx1"
 
     send(w, :msg_to_js, "hello js") # Queue a message to the JS side.


### PR DESCRIPTION
The name "Widget" had little to do with what it did. "Context" is too ambiguous. "Scope" says some things are defined within this scope. We define dependencies and observables.