### PR TITLE
Add possibility of initially empty config file

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ function install_ijulia_config()
     end
 
     # remove previous config
-    config_str = replace(config_str, Regex("\n" * BEGIN_MARKER * ".*" * END_MARKER, "s"), "")
+    config_str = replace(config_str, Regex("\n?" * BEGIN_MARKER * ".*" * END_MARKER, "s"), "")
 
     loadpath = JSON.json(vcat(Pkg.dir(), LOAD_PATH))
     config_str *= """


### PR DESCRIPTION
this might still be a pretty dangerous regex 😬

----

for example,

`"\n###JULIA-WEBIO-CONFIG-BEGIN\nimport sys, os\nif os.path.isfile(\"/srv/julia/pkg/v0.6/WebIO/deps/jlstaticserve.py\"):\n    sys.path.append(\"/srv/julia/pkg/v0.6/WebIO/deps\")\n    c = get_config()\n    c.NotebookApp.nbserver_extensions = {\n        \"jlstaticserve\": True\n    }\nelse:\n    print(\"WebIO config in ~/.jupyter/jupyter_notebook_config.py but WebIO plugin not found\")\n###JULIA-WEBIO-CONFIG-END\n###JULIA-WEBIO-CONFIG-BEGIN\nimport sys, os\nif os.path.isfile(\"/srv/julia/pkg/v0.6/WebIO/deps/jlstaticserve.py\"):\n    sys.path.append(\"/srv/julia/pkg/v0.6/WebIO/deps\")\n    c = get_config()\n    c.NotebookApp.nbserver_extensions = {\n        \"jlstaticserve\": True\n    }\nelse:\n    print(\"WebIO config in ~/.jupyter/jupyter_notebook_config.py but WebIO plugin not found\")\n###JULIA-WEBIO-CONFIG-END\n"`

somehow has 2 `JULIA-WEBIO-CONFIG-END`'s