### PR TITLE
Enable messages to be sent to many web connections

### DIFF
--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -5,6 +5,8 @@ module WebIO
 using Observables
 using Requires
 
+abstract type AbstractConnection end
+
 include("util.jl")
 include("node.jl")
 include("syntax.jl")

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -1,4 +1,3 @@
-abstract type AbstractConnection end
 
 function send(c::AbstractConnection, msg)
     error("No send method for connection of type $(typeof(c))")
@@ -25,10 +24,7 @@ function dispatch(conn::AbstractConnection, data)
     if cmd == "_setup_scope"
         if haskey(scopes, scopeid)
             scope = scopes[scopeid]
-            @async while true
-                msg = take!(scope.outbox)
-                send(conn, msg)
-            end
+            addconnection!(scope.pool, conn)
         else
             log(conn, "Client says it has unknown scope $scopeid", "warn")
         end

--- a/src/providers/blink_setup.jl
+++ b/src/providers/blink_setup.jl
@@ -26,6 +26,9 @@ function Base.send(b::BlinkConnection, data)
     Blink.msg(b.page, Dict(:type=>"webio", :data=>data))
 end
 
+# TODO: I'm not sure what to check here
+Base.isopen(b::BlinkConnection) = true
+
 function WebIO.register_renderable(T::Type)
     Blink.body!(p::Union{Window, Page}, x::T) =
         Blink.body!(p, WebIO.render(x))

--- a/src/providers/blink_setup.jl
+++ b/src/providers/blink_setup.jl
@@ -26,8 +26,7 @@ function Base.send(b::BlinkConnection, data)
     Blink.msg(b.page, Dict(:type=>"webio", :data=>data))
 end
 
-# TODO: I'm not sure what to check here
-Base.isopen(b::BlinkConnection) = true
+Base.isopen(b::BlinkConnection) = Blink.active(b.page)
 
 function WebIO.register_renderable(T::Type)
     Blink.body!(p::Union{Window, Page}, x::T) =

--- a/src/providers/ijulia_setup.jl
+++ b/src/providers/ijulia_setup.jl
@@ -11,6 +11,9 @@ function Base.send(c::IJuliaConnection, data)
     send_comm(c.comm, data)
 end
 
+# TODO: is this the right thing to check?
+Base.isopen(c::IJuliaConnection) = haskey(IJulia.CommManager.comms, c.comm.id)
+
 function WebIO.register_renderable(T::Type)
     WebIO.register_renderable_common(T)
 end

--- a/src/providers/ijulia_setup.jl
+++ b/src/providers/ijulia_setup.jl
@@ -11,7 +11,6 @@ function Base.send(c::IJuliaConnection, data)
     send_comm(c.comm, data)
 end
 
-# TODO: is this the right thing to check?
 Base.isopen(c::IJuliaConnection) = haskey(IJulia.CommManager.comms, c.comm.id)
 
 function WebIO.register_renderable(T::Type)

--- a/src/providers/mux_setup.jl
+++ b/src/providers/mux_setup.jl
@@ -46,6 +46,8 @@ function Base.send(p::WebSockConnection, data)
     write(p.sock, sprint(io->JSON.print(io,data)))
 end
 
+Base.isopen(p::WebSockConnection) = isopen(p.sock)
+
 
 function Mux.Response(o::Union{Node, Scope})
     Mux.Response(

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -66,6 +66,8 @@ function process_messages(pool::ConnectionPool)
                     if isopen(connection)
                         send(connection, msg)
                         msg_sent = true
+                    else
+                        delete!(pool.connections, connection)
                     end
                 end
             end

--- a/test/communication.jl
+++ b/test/communication.jl
@@ -16,11 +16,11 @@ import WebIO: dispatch
    #@test instanceof(w).id == "testctx1"
 
     send(w, :msg_to_js, "hello js") # Queue a message to the JS side.
-    @test take!(w.outbox) == Dict("type"=>"command",
+    @test take!(w.pool.outbox) == Dict("type"=>"command",
                                   "scope"=>"testctx1",
                                   "command"=>:msg_to_js,
                                   "data"=>"hello js")
-    
+
     send(w, :msg_to_js, "hello js again") # Queue it again
 
     conn = TestConn(nothing) # create a test connection
@@ -31,7 +31,7 @@ import WebIO: dispatch
     dispatch(conn, Dict("command" => "_setup_scope",
                         "scope" => "testctx1"))
 
-    yield() # allow a chance for ctx.outbox to write to connection
+    yield() # allow a chance for ctx.pool.outbox to write to connection
 
     # now ctx should have passed on its queued message to connection
     # in TestConn the message is simply stored in its msg ref field

--- a/test/communication.jl
+++ b/test/communication.jl
@@ -54,8 +54,9 @@ import WebIO: dispatch
     # mimic messages coming in from JS side
 
     # no scope named xx
-    dispatch(conn, Dict("command" => "incoming",
-                        "data"=>"hi Julia", "scope"=>"xx"))
+    @test_warn("unknown scope xx",
+        dispatch(conn, Dict("command" => "incoming",
+                            "data"=>"hi Julia", "scope"=>"xx")))
     msg = take!(conn.channel)
     # a warning was raised on receiving a message for an unknown
     # scope xx
@@ -63,8 +64,9 @@ import WebIO: dispatch
     @test contains(msg["message"], "unknown scope xx")
 
     # this should give a warning
-    dispatch(conn, Dict("command" => "incoming",
-                        "data"=>"hi Julia", "scope"=>"testctx1"))
+    @test_warn("incoming does not have a handler for scope id testctx1",
+               dispatch(conn, Dict("command" => "incoming",
+                                   "data"=>"hi Julia", "scope"=>"testctx1")))
 
     msg = Ref("")
     on(x -> msg[] = x, w, "incoming") # setup the handler


### PR DESCRIPTION
This is a rough proposal to fix #71. It replaces the `Scope`'s `outbox` field with a new struct, `ConnectionPool` that holds both the outbox of messages and a set of connections to send those messages to. On construction, the connection pool starts a task that will block until a connection is made, and then will send each message the outbox receives to every open connection. 

Anyway, please let me know if this seems like the right solution. 