### PR TITLE
fix order of operations in process_messages

### DIFF
--- a/src/scope.jl
+++ b/src/scope.jl
@@ -57,8 +57,8 @@ end
 
 function process_messages(pool::ConnectionPool)
     while true
-        ensure_connection(pool)
         msg = fetch(pool.outbox)  # don't take! yet, since we're not sure msg can be sent
+        ensure_connection(pool)
         msg_sent = false
         @sync begin
             for connection in pool.connections

--- a/test/communication.jl
+++ b/test/communication.jl
@@ -76,6 +76,49 @@ import WebIO: dispatch
                         "data"=>"hi Julia!", "scope"=>"testctx1"))
 
     @test msg[] == "hi Julia!"
+
+    # Test connection pool's handling of multiple simultaneous connections
+    @testset "connection pool" begin
+        @testset "sending to two connections" begin
+            outbox = Channel{Any}(1)
+            pool = WebIO.ConnectionPool(outbox)
+            t1 = TestConn(Channel{Any}(1))
+            t2 = TestConn(Channel{Any}(2))
+            # Both connections are added before the message is
+            # sent, so both should receive the message.
+            addconnection!(pool, t1)
+            # Previously, it was possible for `process_messages()`
+            # to advance to waiting for a new message rather than
+            # continuing to look for new connections if the current
+            # task yielded. We do so here to make sure it's fixed.
+            yield()            
+            addconnection!(pool, t2)
+            put!(outbox, "hello")
+            @test take!(t1.channel) == "hello"
+            @test take!(t2.channel) == "hello"
+        end
+
+        @testset "sending to one connection" begin
+            outbox = Channel{Any}(1)
+            pool = WebIO.ConnectionPool(outbox)
+            t1 = TestConn(Channel{Any}(1))
+            t2 = TestConn(Channel{Any}(2))
+            # Only t1 has been added, so only it should receive
+            # the message:
+            addconnection!(pool, t1)
+            put!(outbox, "hello1")
+            @test take!(t1.channel) == "hello1"
+            @test !isready(t2.channel)
+
+            # Now we add a second connection and make sure both
+            # connections get all future messages
+            addconnection!(pool, t2)
+            put!(outbox, "hello2")
+            @test take!(t1.channel) == "hello2"
+            @test take!(t2.channel) == "hello2"
+        end
+    end
+
 end
 
 


### PR DESCRIPTION
Previously, if you did the following:

1. add connection A
2. add connection B
3. send message 1
4. send message 2

then connection A would receive messages 1 and 2, but connection B would only receive 2. That's because the `process_messages()` task would advance past `ensure_connection` when the first connection was found, which meant that connection 2 would not be found until the second message. 

Flipping the order in which we wait for connections and messages fixes the issue, and I've added some tests to make sure.  