### PR TITLE
Use `@require` directly to set up providers, instead of `eval(Main, include(...))` 

### DIFF
--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -16,27 +16,23 @@ include("connection.jl")
 include("iframe.jl")
 include("devsetup.jl")
 
+setup_provider(s::Union{Symbol, AbstractString}) = setup_provider(Val(Symbol(s)))
 export setup_provider
 
-function setup_provider(name)
-    include(joinpath(dirname(@__FILE__), "providers", "$(name)_setup.jl"))
-end
+include(joinpath("providers", "atom.jl"))
+include(joinpath("providers", "blink.jl"))
+include(joinpath("providers", "mux.jl"))
+include(joinpath("providers", "ijulia.jl"))
 
-const providers_initialised = Set{String}()
+const providers_initialised = Set{Symbol}()
 
-function setup(provider)
+function setup(provider::Symbol)
     println("WebIO: setting up $provider")
     setup_provider(provider)
     push!(providers_initialised, provider)
     re_register_renderables()
 end
-
-
-# TODO check Juno since Blink might get loaded after/before?
-@require Mux eval(Main, :(WebIO.setup("mux")))
-@require Blink eval(Main, :(WebIO.setup("blink")))
-@require Juno eval(Main, :(WebIO.setup("atom")))
-@require IJulia eval(Main, :(WebIO.setup("ijulia")))
+setup(provider::AbstractString) = setup(Symbol(provider))
 
 Requires.@init begin
     push!(Observables.addhandler_callbacks, WebIO.setup_comm)

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -16,6 +16,12 @@ include("connection.jl")
 include("iframe.jl")
 include("devsetup.jl")
 
+"""
+    setup_provider(s::Union{Symbol, AbstractString})
+
+Perform any side-effects necessary to set up the given provider. For example,
+in IJulia, this causes the frontend to load the webio javascript bundle. 
+"""
 setup_provider(s::Union{Symbol, AbstractString}) = setup_provider(Val(Symbol(s)))
 export setup_provider
 

--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -23,7 +23,10 @@ function WebIO.register_renderable(T::Type)
     WebIO.register_renderable_common(T)
 end
 
-WebIO.setup_provider(::Val{:atom}) = media(Node, Media.Graphical)
+function WebIO.setup_provider(::Val{:atom})
+    media(Node, Media.Graphical)
+    media(Scope, Media.Graphical)
+end
 WebIO.setup(:atom)
 
 end

--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -1,11 +1,11 @@
+@require Juno begin
+
 using Juno
-using WebIO
 
 function get_page(opts::Dict=Dict())
     Juno.isactive() ? Juno.Atom.blinkplot() : Window(opts).content
 end
 
-media(Node, Media.Graphical)
 Juno.render(::Juno.PlotPane, n::Union{Node, Scope}) =
     (body!(get_page(), n); nothing)
 
@@ -21,4 +21,9 @@ function WebIO.register_renderable(T::Type)
             Juno.render(i, WebIO.render_inline(x))
     end
     WebIO.register_renderable_common(T)
+end
+
+WebIO.setup_provider(::Val{:atom}) = media(Node, Media.Graphical)
+WebIO.setup(:atom)
+
 end

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -1,5 +1,6 @@
-using Blink
-using WebIO
+@require Blink begin
+
+using Blink: Page, loadjs!, body!, Window
 
 immutable BlinkConnection <: WebIO.AbstractConnection
     page::Page
@@ -32,4 +33,9 @@ function WebIO.register_renderable(T::Type)
     Blink.body!(p::Union{Window, Page}, x::T) =
         Blink.body!(p, WebIO.render(x))
     WebIO.register_renderable_common(T)
+end
+
+WebIO.setup_provider(::Val{:blink}) = nothing  # blink setup has no side-effects
+WebIO.setup(:blink)
+
 end

--- a/src/providers/ijulia.jl
+++ b/src/providers/ijulia.jl
@@ -1,7 +1,7 @@
+@require IJulia begin
+
 using IJulia
 using IJulia.CommManager
-
-using WebIO
 
 immutable IJuliaConnection <: AbstractConnection
     comm::CommManager.Comm
@@ -53,4 +53,7 @@ function main()
     nothing
 end
 
-main()
+WebIO.setup_provider(::Val{:ijulia}) = main() # calling setup_provider(Val(:ijulia)) will display the setup javascript
+WebIO.setup(:ijulia)
+
+end

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -1,6 +1,7 @@
+@require Mux begin
+
 using Mux
 using JSON
-using WebIO
 
 """
     webio_serve(app, port=8000)
@@ -8,18 +9,18 @@ using WebIO
 Serve a Mux app which might return a WebIO node.
 """
 function webio_serve(app, port=8000)
-    @app http = (
+    http = Mux.App(Mux.mux(
         Mux.defaults,
         app,
-        Mux.notfound(),
-    )
+        Mux.notfound()
+    ))
 
-    @app websock = (
+    websock = Mux.App(Mux.mux(
         Mux.wdefaults,
         route("/webio-socket", create_socket),
         Mux.wclose,
         Mux.notfound(),
-    )
+    ))
 
     serve(http, websock, port)
 end
@@ -70,4 +71,9 @@ end
 function WebIO.register_renderable(T::Type)
     Mux.Response(x::T) = Mux.Response(WebIO.render(x))
     WebIO.register_renderable_common(T)
+end
+
+WebIO.setup_provider(::Val{:mux}) = nothing # Mux setup has no side-effects
+WebIO.setup(:mux)
+
 end

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -2,6 +2,7 @@
 
 using Mux
 using JSON
+export webio_serve
 
 """
     webio_serve(app, port=8000)


### PR DESCRIPTION
Fixes #104 
Fixes #105 (using the same change mentioned in that issue)

I find this a bit easier to understand than the current version in `master`, but ultimately whether this is better than the `eval(Main, include(...))` approach is a matter of opinion. What do you think? 