### PR TITLE
Add a test for scope imports in Blink

### DIFF
--- a/assets/webio/test/trivial_import.js
+++ b/assets/webio/test/trivial_import.js
@@ -1,0 +1,6 @@
+// A trivial importable module that simply produces "ok".
+// Used for testing the WebIO Scope imports machinery.
+(function() {
+	x = "ok";
+	return {x: x}
+})()

--- a/assets/webio/test/trivial_import.js
+++ b/assets/webio/test/trivial_import.js
@@ -1,6 +1,14 @@
 // A trivial importable module that simply produces "ok".
 // Used for testing the WebIO Scope imports machinery.
-(function() {
-	x = "ok";
-	return {x: x}
-})()
+
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else {
+        // Browser globals
+        root.amdWeb = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    return {x: "ok"}
+}));

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -87,10 +87,14 @@ end
         end
 
         @testset "global URL, no http:" begin
+            # TODO: change this to a permanent URL because this CSAIL account
+            # will eventually expire. 
             @test scope_import(w, "//people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
 
         @testset "global URL, with http:" begin
+            # TODO: change this to a permanent URL because this CSAIL account
+            # will eventually expire. 
             @test scope_import(w, "http://people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
     end

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -87,11 +87,11 @@ end
         end
 
         @testset "global URL, no http:" begin
-            @test scope_import(w, "//people.csail.mit.edu/rdeits/trivial_import.js") == "ok"
+            @test scope_import(w, "//people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
 
         @testset "global URL, with http:" begin
-            @test scope_import(w, "http://people.csail.mit.edu/rdeits/trivial_import.js") == "ok"
+            @test scope_import(w, "http://people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
     end
 end

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -69,8 +69,8 @@ end
             # Put the result in a channel so we can watch for it
             put!(output, x)
         end
-        onimport(scope, @JSExpr.js function (x)
-            $js_to_julia[] = x
+        onimport(scope, @JSExpr.js function (mod)
+            $js_to_julia[] = mod.x
         end)
         body!(w, scope)
 

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -24,7 +24,6 @@ function with_timeout(f::Function, timeout)
     take!(c)
 end
 
-
 @testset "Blink mocks" begin
 
     # open window and wait for it to initialize
@@ -58,6 +57,42 @@ end
         # Send a message and make sure we get it back from JS
         julia_to_js[] = "hello Blink"
         @test with_timeout(() -> take!(output), 5) == "hello Blink"
+    end
+
+    function scope_import(w::Window, url::AbstractString)
+        scope = Scope(
+            imports=[url]
+        )
+        js_to_julia = Observable{Any}(scope, "inbox", "")
+        output = Channel{Any}(1)
+        on(js_to_julia) do x
+            # Put the result in a channel so we can watch for it
+            put!(output, x)
+        end
+        onimport(scope, @JSExpr.js function (x)
+            $js_to_julia[] = x
+        end)
+        body!(w, scope)
+
+        return with_timeout(() -> take!(output), 5)
+    end
+
+    @testset "scope imports" begin
+        @testset "local package, absolute" begin
+            @test scope_import(w, "/pkg/WebIO/webio/test/trivial_import.js") == "ok"
+        end
+
+        @testset "local package, relative" begin
+            @test scope_import(w, "pkg/WebIO/webio/test/trivial_import.js") == "ok"
+        end
+
+        @testset "global URL, no http:" begin
+            @test scope_import(w, "//people.csail.mit.edu/rdeits/trivial_import.js") == "ok"
+        end
+
+        @testset "global URL, with http:" begin
+            @test scope_import(w, "http://people.csail.mit.edu/rdeits/trivial_import.js") == "ok"
+        end
     end
 end
 


### PR DESCRIPTION
This PR adds tests for scope imports with the following URL types:

* `/pkg/Foo/...`
* `pkg/Foo/...`
* `//public/url/...`
* `http://public/url/...`

~~Currently only the first one actually works on Blink (see #107 ), so we should fix those issues before merging.~~

Edit: all 4 URLs are working now! 

In the long run, we can change the public URL used here to the permanent github URL of the `trivial_import.js` file, but since it's not committed yet I'm currently just serving it from my personal public folder. That's easy to change later. 