### PR TITLE
don't limit the number of pending messages for a scope

### DIFF
--- a/src/scope.jl
+++ b/src/scope.jl
@@ -105,7 +105,7 @@ const scopes = Dict{String, Scope}()
 
 function Scope(id::String=newid("scope");
         dom=dom"span"(),
-        outbox::Channel=Channel{Any}(32),
+        outbox::Channel=Channel{Any}(Inf),
         observs::Dict=Dict(),
         private_obs::Set{String}=Set{String}(),
         dependencies=nothing,


### PR DESCRIPTION
Currently, a scope which is not yet being rendered anywhere can only accept 32 messages before it starts blocking. I don't think there's any reason for that limit to exist, so I've removed it. 