### PR TITLE
refactor register_renderable to not rely on overwriting a method

### DIFF
--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -12,7 +12,7 @@ Juno.render(::Juno.PlotPane, n::Union{Node, Scope}) =
 Juno.render(i::Juno.Editor, n::Union{Node, Scope}) =
     Juno.render(i, Text("$(n.instanceof) Node with $(n._descendants_count) descendent(s)"))
 
-function WebIO.register_renderable(T::Type)
+function WebIO.register_renderable(T::Type, ::Val{:atom})
     media(T, Media.Graphical)
     Media.render(::Juno.PlotPane, x::T) =
         (body!(get_page(), WebIO.render(x)); nothing)
@@ -20,7 +20,6 @@ function WebIO.register_renderable(T::Type)
         Juno.render(i::Juno.Editor, x::T) =
             Juno.render(i, WebIO.render_inline(x))
     end
-    WebIO.register_renderable_common(T)
 end
 
 function WebIO.setup_provider(::Val{:atom})

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -29,10 +29,9 @@ end
 
 Base.isopen(b::BlinkConnection) = Blink.active(b.page)
 
-function WebIO.register_renderable(T::Type)
+function WebIO.register_renderable(T::Type, ::Val{:blink})
     Blink.body!(p::Union{Window, Page}, x::T) =
         Blink.body!(p, WebIO.render(x))
-    WebIO.register_renderable_common(T)
 end
 
 WebIO.setup_provider(::Val{:blink}) = nothing  # blink setup has no side-effects

--- a/src/providers/ijulia.jl
+++ b/src/providers/ijulia.jl
@@ -13,9 +13,7 @@ end
 
 Base.isopen(c::IJuliaConnection) = haskey(IJulia.CommManager.comms, c.comm.id)
 
-function WebIO.register_renderable(T::Type)
-    WebIO.register_renderable_common(T)
-end
+WebIO.register_renderable(T::Type, ::Val{:ijulia}) = nothing
 
 function main()
     display(HTML("""

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -69,9 +69,8 @@ function Mux.Response(o::Union{Node, Scope})
     )
 end
 
-function WebIO.register_renderable(T::Type)
+function WebIO.register_renderable(T::Type, ::Val{:mux})
     Mux.Response(x::T) = Mux.Response(WebIO.render(x))
-    WebIO.register_renderable_common(T)
 end
 
 WebIO.setup_provider(::Val{:mux}) = nothing # Mux setup has no side-effects

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -25,7 +25,6 @@ function with_timeout(f::Function, timeout)
 end
 
 @testset "Blink mocks" begin
-
     # open window and wait for it to initialize
     w = Window(Dict(:show => false))
 
@@ -88,16 +87,36 @@ end
 
         @testset "global URL, no http:" begin
             # TODO: change this to a permanent URL because this CSAIL account
-            # will eventually expire. 
+            # will eventually expire.
             @test scope_import(w, "//people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
 
         @testset "global URL, with http:" begin
             # TODO: change this to a permanent URL because this CSAIL account
-            # will eventually expire. 
+            # will eventually expire.
             @test scope_import(w, "http://people.csail.mit.edu/rdeits/webio_tests/trivial_import.js") == "ok"
         end
     end
+end
+
+
+example_renderable_was_rendered = false
+
+struct ExampleRenderableType
+end
+
+function WebIO.render(::ExampleRenderableType)
+    global example_renderable_was_rendered
+    example_renderable_was_rendered = true
+    Node(:div, "hello world")
+end
+
+WebIO.register_renderable(ExampleRenderableType)
+
+@testset "register_renderable" begin
+    w = Window(Dict(:show => false))
+    body!(w, ExampleRenderableType())
+    @test example_renderable_was_rendered
 end
 
 notinstalled && AtomShell.uninstall()


### PR DESCRIPTION
resolves #119

Now, each provider defines `register_renderable(::Type{T}, ::Val{provider})` so their method signatures don't conflict and there should be no dependence on load order. 