### PR TITLE
Add LaTeXString support.

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -11,6 +11,10 @@ render(::Nothing) = ""
 render(x::Any) =
     dom"div"(; setInnerHtml=richest_html(x))
 
+@require LaTeXStrings begin
+    render(x::LaTeXStrings.LaTeXString) = render(x.s)
+end
+
 const renderable_types = Type[]
 """
     `WebIO.register_renderable(MyType::Type)`


### PR DESCRIPTION
A very simple addition which allows [LaTeXStrings](https://github.com/stevengj/LaTeXStrings.jl) to be rendered. I have tested this for Jupyter.