### PR TITLE
Make Mux work on non-root routes

### DIFF
--- a/assets/providers/mux_setup.js
+++ b/assets/providers/mux_setup.js
@@ -1,5 +1,5 @@
 (function () {
-    function wsurl(suffix) {
+    function wsurl() {
         var loc = window.location, new_uri;
         if (loc.protocol === "https:") {
                 new_uri = "wss:";
@@ -7,18 +7,39 @@
                 new_uri = "ws:";
         }
         new_uri += "//" + loc.host;
-        new_uri += loc.pathname + suffix;
+        new_uri += loc.pathname;
         return new_uri;
     }
 
-    var ws = new WebSocket(wsurl("/webio-socket"));
-    ws.onopen = function () {
-        WebIO.triggerConnected();
+    function tryconnect(url) {
+
+        var ws = new WebSocket(url + "/webio-socket");
+        ws.onopen = function () {
+            WebIO.sendCallback = function (msg) {
+                ws.send(JSON.stringify(msg))
+            }
+
+            ws.onmessage = function (evt) {
+                WebIO.dispatch(JSON.parse(evt.data));
+            }
+
+            WebIO.triggerConnected()
+        }
+        ws.onclose = function (evt) {
+            if (evt.code === 1005) {
+                // no status code recv -- happens when 404
+                url = url.replace(/\/+$/, "")
+                url = url.match(/.*\//)[0]; // dirname
+                url = url.replace(/\/+$/, "")
+                if (url === "http:" || url === "https:") {
+                    // we tried everything!
+                    return
+                } else {
+                    tryconnect(url)
+                }
+            }
+        }
     }
-    WebIO.sendCallback = function (msg) {
-        ws.send(JSON.stringify(msg))
-    }
-    ws.onmessage = function (evt) {
-        WebIO.dispatch(JSON.parse(evt.data));
-    }
+
+    tryconnect(wsurl())
 })();

--- a/assets/webio/dist/bundle.js
+++ b/assets/webio/dist/bundle.js
@@ -195,7 +195,7 @@ function mount(target, data)
 
 function send(scope, cmd, data)
 {
-    scope.sendCallback(message(scope, cmd, data));
+    WebIO.sendCallback(message(scope, cmd, data));
 }
 
 function setval(ob, val) {

--- a/assets/webio/webio.js
+++ b/assets/webio/webio.js
@@ -94,7 +94,7 @@ function mount(target, data)
 
 function send(scope, cmd, data)
 {
-    scope.sendCallback(message(scope, cmd, data));
+    WebIO.sendCallback(message(scope, cmd, data));
 }
 
 function setval(ob, val) {


### PR DESCRIPTION
After doing this change I realized that we assume Mux to be running on the root of the domain when we assume `/assetserver/hash` urls will work. But this is quite robust anyway.