### PR TITLE
more updates to make importing WebIO possible on 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ matrix:
     - os: linux
       julia: 0.6
       env: TESTCMD="xvfb-run julia"
-    # - os: linux
-    #   julia: nightly
-    #   env: TESTCMD="xvfb-run julia"
+    - os: linux
+      julia: nightly
+      env: TESTCMD="xvfb-run julia"
     - os: osx
       julia: 0.6
       env: TESTCMD="julia"
-    # - os: osx
-    #   julia: nightly
-    #   env: TESTCMD="julia"
+    - os: osx
+      julia: nightly
+      env: TESTCMD="julia"
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - $TESTCMD -e 'Pkg.clone(pwd()); Pkg.add("Blink"); Pkg.build("Blink"); import Blink; Pkg.build("WebIO"); Pkg.test("WebIO"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 JSON 0.7
 FunctionalCollections
 Observables 0.0.3

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,7 +14,7 @@ function install_ijulia_config()
     # remove previous config
     config_str = replace(config_str, Regex("\n?" * BEGIN_MARKER * ".*" * END_MARKER * "\n?", "s"), "")
 
-    if VERSION < v"0.7.0-dev"
+    if VERSION < v"0.7.0-"
         # enables legacy /pkg/ server in Jupyter
         loadpath = JSON.json(vcat(Pkg.dir(), LOAD_PATH))
         write("load_paths.json", loadpath)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,7 +14,12 @@ function install_ijulia_config()
     # remove previous config
     config_str = replace(config_str, Regex("\n?" * BEGIN_MARKER * ".*" * END_MARKER * "\n?", "s"), "")
 
-    loadpath = JSON.json(vcat(Pkg.dir(), LOAD_PATH))
+    if VERSION < v"0.7.0-dev"
+        # enables legacy /pkg/ server in Jupyter
+        loadpath = JSON.json(vcat(Pkg.dir(), LOAD_PATH))
+        write("load_paths.json", loadpath)
+    end
+
     config_str *= """
 
     $BEGIN_MARKER
@@ -30,7 +35,6 @@ function install_ijulia_config()
     $END_MARKER
     """
     write(config_file, config_str)
-    write("load_paths.json", loadpath)
 end
 
 install_ijulia_config()

--- a/deps/jlstaticserve.py
+++ b/deps/jlstaticserve.py
@@ -61,11 +61,16 @@ def load_jupyter_server_extension(nb_server_app):
     host_pattern = '.*$'
     route_pattern_old = url_path_join(web_app.settings['base_url'], '/pkg/([^/]+)/(.*)$')
     route_pattern = url_path_join(web_app.settings['base_url'], '/(assetserver)/(.*)$')
-    with open(os.path.join(os.path.dirname(__file__), "load_paths.json"), "r") as paths_file:
-        JuliaPackageAssetServer.julia_load_path = json.load(paths_file)
-    print("Will serve asset files from any Julia package under", JuliaPackageAssetServer.julia_load_path)
-    web_app.add_handlers(
-            host_pattern, [(route_pattern_old, JuliaPackageAssetServer)])
+    paths_file = os.path.join(os.path.dirname(__file__), "load_paths.json")
+    if not os.path.isfile(paths_file):
+        # Disable /pkg/ router
+        JuliaPackageAssetServer.julia_load_path = None
+    else:
+        with open(paths_file, "r") as paths_file:
+            JuliaPackageAssetServer.julia_load_path = json.load(paths_file)
+        print("Will serve asset files from any Julia package under", JuliaPackageAssetServer.julia_load_path)
+        web_app.add_handlers(
+                host_pattern, [(route_pattern_old, JuliaPackageAssetServer)])
 
     web_app.add_handlers(
             host_pattern, [(route_pattern, JuliaPackageAssetServer)])

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -29,11 +29,9 @@ export setup_provider
 
 include(joinpath("providers", "atom.jl"))
 include(joinpath("providers", "blink.jl"))
-include(joinpath("providers", "mux.jl"))
 include(joinpath("providers", "ijulia.jl"))
 
 const providers_initialised = Set{Symbol}()
-
 function setup(provider::Symbol)
     haskey(ENV, "WEBIO_DEBUG") && println("WebIO: setting up $provider")
     setup_provider(provider)
@@ -44,6 +42,10 @@ setup(provider::AbstractString) = setup(Symbol(provider))
 
 Requires.@init begin
     push!(Observables.addhandler_callbacks, WebIO.setup_comm)
+    try
+        include(joinpath("src", "providers", "mux.jl"))
+    catch
+        include(joinpath("..", "src", "providers", "mux.jl"))
+    end
 end
-
 end # module

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -43,9 +43,9 @@ setup(provider::AbstractString) = setup(Symbol(provider))
 Requires.@init begin
     push!(Observables.addhandler_callbacks, WebIO.setup_comm)
     try
-        include(joinpath("src", "providers", "mux.jl"))
+        include(joinpath(@__DIR__(), "src", "providers", "mux.jl"))
     catch
-        include(joinpath("..", "src", "providers", "mux.jl"))
+        include(joinpath(@__DIR__(), "..", "src", "providers", "mux.jl"))
     end
 end
 end # module

--- a/src/node.jl
+++ b/src/node.jl
@@ -106,7 +106,7 @@ function JSON.lower(n::Node)
         "nodeType" => nodetype(n),
         "instanceArgs" => JSON.lower(n.instanceof),
         "children" => map!(render,
-                           Vector{Any}(length(children(n))),
+                           Vector{Any}(undef, length(children(n))),
                            children(n)),
         "props" => props(n),
     )
@@ -115,11 +115,11 @@ end
 ## TODO -- optimize
 function escapeHTML(i::String)
     # Refer to http://stackoverflow.com/a/7382028/3822752 for spec. links
-    o = replace(i, "&", "&amp;")
-    o = replace(o, "\"", "&quot;")
-    o = replace(o, "'", "&#39;")
-    o = replace(o, "<", "&lt;")
-    o = replace(o, ">", "&gt;")
+    o = replace(i, "&" => "&amp;")
+    o = replace(o, "\"" => "&quot;")
+    o = replace(o, "'" => "&#39;")
+    o = replace(o, "<" => "&lt;")
+    o = replace(o, ">" => "&gt;")
     return o
 end
 

--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -1,4 +1,4 @@
-@require Juno begin
+@require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" begin
 
 using Juno
 
@@ -14,11 +14,11 @@ Juno.render(i::Juno.Editor, n::Union{Node, Scope}) =
 
 function WebIO.register_renderable(T::Type, ::Val{:atom})
     media(T, Media.Graphical)
-    Media.render(::Juno.PlotPane, x::T) =
-        (body!(get_page(), WebIO.render(x)); nothing)
+    eval(:(Media.render(::Juno.PlotPane, x::$T) =
+           (body!(get_page(), WebIO.render(x)); nothing)))
     if method_exists(WebIO.render_inline, (T,))
-        Juno.render(i::Juno.Editor, x::T) =
-            Juno.render(i, WebIO.render_inline(x))
+        eval(:(Juno.render(i::Juno.Editor, x::$T) =
+               Juno.render(i, WebIO.render_inline(x))))
     end
 end
 

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -1,4 +1,4 @@
-@require Blink begin
+@require Blink="ad839575-38b3-5650-b840-f874b8c74a25" begin
 
 using AssetRegistry
 
@@ -10,6 +10,7 @@ const blinksetup = joinpath(dirname(@__FILE__), "..", "..",
                             "blink_setup.js")
 
 using Blink: Page, loadjs!, body!, Window
+using Compat.Sockets
 
 struct BlinkConnection <: WebIO.AbstractConnection
     page::Page
@@ -36,15 +37,15 @@ function Blink.body!(p::Window, x::Union{Node, Scope})
     body!(p.content, x)
 end
 
-function Base.send(b::BlinkConnection, data)
+function Compat.Sockets.send(b::BlinkConnection, data)
     Blink.msg(b.page, Dict(:type=>"webio", :data=>data))
 end
 
 Base.isopen(b::BlinkConnection) = Blink.active(b.page)
 
 function WebIO.register_renderable(T::Type, ::Val{:blink})
-    Blink.body!(p::Union{Window, Page}, x::T) =
-        Blink.body!(p, WebIO.render(x))
+    eval(:(Blink.body!(p::Union{Window, Page}, x::$T) =
+           Blink.body!(p, WebIO.render(x))))
 end
 
 WebIO.setup_provider(::Val{:blink}) = nothing  # blink setup has no side-effects

--- a/src/providers/ijulia.jl
+++ b/src/providers/ijulia.jl
@@ -1,14 +1,15 @@
-@require IJulia begin
+@require IJulia="7073ff75-c697-5162-941a-fcdaad2a7d2a" begin
 
 using IJulia
 using IJulia.CommManager
 using AssetRegistry
+using Compat.Sockets
 
 struct IJuliaConnection <: AbstractConnection
     comm::CommManager.Comm
 end
 
-function Base.send(c::IJuliaConnection, data)
+function Compat.Sockets.send(c::IJuliaConnection, data)
     send_comm(c.comm, data)
 end
 
@@ -20,9 +21,9 @@ function main()
     if !IJulia.inited
         # If IJulia has not been initialized and connected to Jupyter itself,
         # then we have no way to display anything in the notebook and no way
-        # to set up comms, so this function cannot run. That's OK, because 
-        # any IJulia kernels will start up with a fresh process and a fresh 
-        # copy of WebIO and IJulia. 
+        # to set up comms, so this function cannot run. That's OK, because
+        # any IJulia kernels will start up with a fresh process and a fresh
+        # copy of WebIO and IJulia.
         return
     end
     key = AssetRegistry.register(joinpath(@__DIR__, "..", "..", "assets"))

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -1,8 +1,8 @@
-@require Mux begin
-
+@require Mux="a975b10e-0019-58db-a62f-e48ff68538c9" begin
 using Mux
 using JSON
 using AssetRegistry
+
 export webio_serve
 
 """
@@ -10,6 +10,7 @@ export webio_serve
 
 Serve a Mux app which might return a WebIO node.
 """
+#print("HHHEHHHHHHHHHHHHHBBDBDHBDHBDBDDBBDDBHBDHBDBDBHDB")
 function webio_serve(app, port=8000)
     http = Mux.App(Mux.mux(
         Mux.defaults,
@@ -71,9 +72,9 @@ function Mux.Response(o::Union{Node, Scope})
     )
 end
 
-function WebIO.register_renderable(T::Type, ::Val{:mux})
-    Mux.Response(x::T) = Mux.Response(WebIO.render(x))
-end
+#function WebIO.register_renderable(T::Type, ::Val{:mux})
+Mux.Response(x::T) = Mux.Response(WebIO.render(x))
+#end
 
 WebIO.setup_provider(::Val{:mux}) = nothing # Mux setup has no side-effects
 WebIO.setup(:mux)

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -10,7 +10,6 @@ export webio_serve
 
 Serve a Mux app which might return a WebIO node.
 """
-#print("HHHEHHHHHHHHHHHHHBBDBDHBDHBDBDDBBDDBHBDHBDBDBHDB")
 function webio_serve(app, port=8000)
     http = Mux.App(Mux.mux(
         Mux.defaults,

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,3 +2,4 @@ Blink
 JSExpr
 IJulia
 NBInclude
+Mux

--- a/test/communication.jl
+++ b/test/communication.jl
@@ -2,7 +2,7 @@ mutable struct TestConn <: AbstractConnection
     channel::Channel
 end
 
-function Base.send(c::TestConn, msg)
+function Compat.Sockets.send(c::TestConn, msg)
     put!(c.channel, msg)
 end
 
@@ -91,7 +91,7 @@ import WebIO: dispatch
             # to advance to waiting for a new message rather than
             # continuing to look for new connections if the current
             # task yielded. We do so here to make sure it's fixed.
-            yield()            
+            yield()
             addconnection!(pool, t2)
             put!(outbox, "hello")
             @test take!(t1.channel) == "hello"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using WebIO
-using Base.Test
+using Compat.Test
+using Compat.Sockets
 
 import WebIO: DOM, instanceof
 @testset "node" begin


### PR DESCRIPTION
(this is a PR against the branch from #145 )

With these changes, I can do `using WebIO, Mux` on Julia v0.7-beta with no deprecation warnings. It still doesn't actually *work*, but at least we're getting closer. 