### PR TITLE
demonstrate simple rendering of Observables

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,5 +406,5 @@ clock_obs = Observable(timestr())
     sleep(1)
     clock_obs[] = timestr()
 end
-WebIO.render(clock_obs)
+clock_obs
 ```

--- a/README.md
+++ b/README.md
@@ -396,3 +396,15 @@ w(
 
 The javascript function passed to `onjs` gets the value of the update as the argument. `this` is set to the Scope object. Notice the use of `this.dom.querySelector("#clock")`. `this.dom` contains the rendered DOM of the scope. `querySelector("#<id>")` will look up the element which has the id `<id>`. `clock.textContent = val` will set the text contained in `clock`, the DOM element.
 
+For an even easier way to send values from Julia to JavaScript, we can simply rely on the fact that WebIO knows how to render `Observable`s directly to HTML. In this case WebIO will automatically construct a `Scope` and insert the relevant JavaScript to update the rendered content whenever the `Observable` changes value:
+
+```julia
+timestr() = Dates.format(now(), "HH:MM:SS")
+
+clock_obs = Observable(timestr())
+@async while true
+    sleep(1)
+    clock_obs[] = timestr()
+end
+WebIO.render(clock_obs)
+```

--- a/examples/jupyter-demo.ipynb
+++ b/examples/jupyter-demo.ipynb
@@ -200,11 +200,32 @@
     "  ),\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For an even easier way to send values from Julia to JavaScript, we can simply rely on the fact that WebIO knows how to render `Observable`s directly to HTML. In this case WebIO will automatically construct a `Scope` and insert the relevant JavaScript to update the rendered content whenever the `Observable` changes value:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clock_obs = Observable(timestr())\n",
+    "@async while true\n",
+    "    sleep(1)\n",
+    "    clock_obs[] = timestr()\n",
+    "end\n",
+    "WebIO.render(clock_obs)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.6.2",
+   "display_name": "Julia 0.6.4",
    "language": "julia",
    "name": "julia-0.6"
   },
@@ -212,7 +233,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.2"
+   "version": "0.6.4"
   }
  },
  "nbformat": 4,

--- a/examples/jupyter-demo.ipynb
+++ b/examples/jupyter-demo.ipynb
@@ -219,7 +219,7 @@
     "    sleep(1)\n",
     "    clock_obs[] = timestr()\n",
     "end\n",
-    "WebIO.render(clock_obs)"
+    "clock_obs"
    ]
   }
  ],


### PR DESCRIPTION
This works just fine in IJulia, but in Blink, I had to do: 

```julia
body!(Window(), WebIO.render(clock_obs))
```

instead of:

```julia
body!(Window(), clock_obs)
```

Doing `register_renderable(Observable)` didn't seem to change that. Maybe the `register_renderable` for Blink isn't working? 