### PR TITLE
Proposal: new `node()` vararg constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ First, load the front end package (e.g. Blink or Mux; IJulia and Atom packages a
 Whenever a code cell returns a `WebIO.Node` object, IJulia will render it. For example,
 
 ```julia
-In[*]: Node(:div, "Hello, World")
+In[*]: node(:div, "Hello, World")
 ```
+
+The `node` (lowercase) function is a helper function which provides a convenient way to construct `WebIO.Node` objects.
 
 - On **Blink**
 
@@ -74,7 +76,7 @@ Return the WebIO Node from a web app to render it. Use `webio_serve` to serve th
 
 ```julia
 function myapp(req) # an "App" takes a request, returns the output
-    Node(:div, "Hello, World!")
+    node(:div, "Hello, World!")
 end
 
 webio_serve(page("/", req -> myapp(req)))
@@ -95,9 +97,9 @@ Let's say you want to display the following HTML:
 You can create a nested Node object:
 
 ```julia
-Node(:ul,
-    Node(:li, "get milk"),
-    Node(:li, "make a pie"), attributes=Dict(:class => "my-list"))
+node(:ul,
+    node(:li, "get milk"),
+    node(:li, "make a pie"), attributes=Dict(:class => "my-list"))
 ```
 
 `attributes` keyword argument sets the attributes of the HTML element.
@@ -107,7 +109,7 @@ Any other keyword argument to `DOM` is set as the property of the [DOM object](h
 For example,
 
 ```julia
-Node(:ul, className="my-list")
+node(:ul, className="my-list")
 ```
 
 does the equivalent of the following in JavaScript:
@@ -121,7 +123,7 @@ element.className = "my-list"
 Some DOM properties can themselves be objects, you can set them using Julia dictionaries:
 
 ```julia
-Node(:div, "Hello, World",
+node(:div, "Hello, World",
      style=Dict(:backgroundColor => "black",
                 :color => "white",
                 :padding => "12px"))
@@ -144,7 +146,7 @@ This is in turn equivalent to:
 
 and hence also equivalent to:
 ```html
-Node(:div, attributes=Dict(:style => "background-color: black; color: white; padding: 12px"))
+node(:div, attributes=Dict(:style => "background-color: black; color: white; padding: 12px"))
 ```
 
 ### The `dom""` macro
@@ -158,7 +160,7 @@ dom"div.<class>#<id>[<attr>=<value>,...]"(children...; props...)
 And is equivalent to:
 
 ```julia
-Node(:div, children..., className="<class>", id="<id>",
+node(:div, children..., className="<class>", id="<id>",
      attributes=Dict(attr1=>val1, attr2=>val2...); props...)
 ```
 
@@ -170,7 +172,7 @@ Everything except the tag ('div' in the example) is optional. So,
 WebIO.render
 ------------
 
-WebIO exports `WebIO.render` generic function which can be extended to define how to render something into WebIO's DOM. Think of it as a better version of `show(io::IO, m::MIME"text/html", x)`. Whenever an object is used as an argument to `Node`, this `render` function will be called to create the `Node` object to display.
+WebIO exports `WebIO.render` generic function which can be extended to define how to render something into WebIO's DOM. Think of it as a better version of `show(io::IO, m::MIME"text/html", x)`. Whenever an object is used as an argument to `node`, this `render` function will be called to create the `Node` object to display.
 
 For example, a TodoItem type like:
 
@@ -200,7 +202,7 @@ A todo list which contains a vector of `TodoItem`s and possibly a `title` field,
 ```julia
 struct TodoList
     title::String
-    list::Vector{TodoItem}
+    items::Vector{TodoItem}
 end
 
 mylist = TodoList("My todo list",
@@ -216,7 +218,7 @@ function render(list::TodoList)
     dom"div"(
         dom"h2"(list.title),
         dom"div.todo-list"(
-            list.items # each element will be rendered using WebIO.render
+            list.items... # each element will be rendered using WebIO.render
         )
     )
 end
@@ -224,7 +226,7 @@ end
 
 ## Executing JavaScript
 
-Event handlers can be set up by passing a dict as the `events` keyword argument to `Node`, (and hence `dom"foo"`). For example,
+Event handlers can be set up by passing a dict as the `events` keyword argument to `node`, (and hence `dom"foo"`). For example,
 
 ```julia
 dom"button"("Greet",

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Observables 0.0.3
 AssetRegistry
 Requires
 Compat 0.59
+Widgets 0.2.2

--- a/examples/jupyter-demo.ipynb
+++ b/examples/jupyter-demo.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Node(:div, \"Hello, World\")"
+    "node(:div, \"Hello, World\")"
    ]
   },
   {
@@ -61,9 +61,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Node(:ul,\n",
-    "    Node(:li, \"get milk\"),\n",
-    "    Node(:li, \"make a pie\"), attributes=Dict(:class => \"my-list\"))"
+    "node(:ul,\n",
+    "    node(:li, \"get milk\"),\n",
+    "    node(:li, \"make a pie\"), attributes=Dict(:class => \"my-list\"))"
    ]
   },
   {
@@ -78,7 +78,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "w = Scope(imports=[\"//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.11/p5.js\"])\n",
@@ -99,7 +101,7 @@
     "    @new p5(sketch, this.dom.querySelector(\"#container\"))\n",
     "end)\n",
     "\n",
-    "w(dom\"div#container\"())"
+    "n = w(dom\"div#container\"())"
    ]
   },
   {
@@ -204,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.6.2",
+   "display_name": "Julia 0.6.4",
    "language": "julia",
    "name": "julia-0.6"
   },
@@ -212,7 +214,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.2"
+   "version": "0.6.4"
   }
  },
  "nbformat": 4,

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -6,6 +6,7 @@ using Observables
 using Requires
 using AssetRegistry
 using Compat
+import Widgets: node
 
 abstract type AbstractConnection end
 

--- a/src/iframe.jl
+++ b/src/iframe.jl
@@ -4,8 +4,8 @@ function iframe(dom)
     str = stringmime("text/html", dom)
 
     s = Scope()
-    s.dom = Node(:div,
-                 Node(:iframe, id="ifr", style=Dict("width"=>"100%"),
+    s.dom = node(:div,
+                 node(:iframe, id="ifr", style=Dict("width"=>"100%"),
                       attributes=Dict("src"=>"javascript:void(0)","frameborder"=>0, "scrolling"=>"no", "height"=>"100%")),
                 style=Dict("overflow"=>"hidden"),
     )

--- a/src/node.jl
+++ b/src/node.jl
@@ -26,6 +26,8 @@ end
            node(instanceof, children...; props...))
 
 promote_instanceof(x) = x
+promote_instanceof(s::Symbol) = DOM(:html, s)
+promote_instanceof(s::AbstractString) = promote_instanceof(Symbol(s))
 
 nodetype(n::Node) = typename(n.instanceof)
 typename(n::T) where {T} = string(T.name.name)
@@ -51,7 +53,6 @@ struct DOM
     tag::Symbol
 end
 
-promote_instanceof(s::Symbol) = DOM(:html, s)
 
 export children, setchildren, instanceof, setinstanceof, props, setprops
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -56,7 +56,7 @@ promote_instanceof(s::Symbol) = DOM(:html, s)
 export children, setchildren, instanceof, setinstanceof, props, setprops
 
 children(n::Node) = n.children
-setchildren(n::Node, children) = Node(n.instanceof, _pvec(children), n.props)
+setchildren(n::Node, children) = Node(n.instanceof, PersistentVector{Any}(collect(children)), n.props)
 instanceof(n::Node) = n.instanceof
 setinstanceof(n::Node, instanceof) = Node(instanceof, n.children, n.props)
 props(n::Node) = n.props

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -237,7 +237,7 @@ function JSON.lower(x::Scope)
 end
 
 function render(s::Scope)
-    Node(s, s.dom)
+    node(s, s.dom)
 end
 
 function send(ctx::Scope, key, data)

--- a/src/syntax.jl
+++ b/src/syntax.jl
@@ -31,7 +31,7 @@ function makedom(tag, props)
         DOM(:html, tag)
     end
     function dom(args...; kwargs...)
-        n = Node(d, args...)(Dict(kwargs))
+        n = node(d, args...)(Dict(kwargs))
         isempty(props) ? n : n(props)
     end
 end

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -112,7 +112,7 @@ end
 function WebIO.render(::ExampleRenderableType)
     global example_renderable_was_rendered
     example_renderable_was_rendered = true
-    Node(:div, "hello world")
+    node(:div, "hello world")
 end
 
 WebIO.register_renderable(ExampleRenderableType)

--- a/test/ijulia-tests.jl
+++ b/test/ijulia-tests.jl
@@ -1,8 +1,8 @@
 # Test for load-order-specific issues with WebIO and IJulia
-# when running outside of Jupyter. 
+# when running outside of Jupyter.
 #
 # See: https://github.com/JuliaGizmos/WebIO.jl/issues/117
-using WebIO 
+using WebIO
 using IJulia
 @testset "IJulia initialization" begin
     @test :ijulia in WebIO.providers_initialised
@@ -10,9 +10,9 @@ end
 
 
 # Test the demo jupyter notebook and make sure all of its cells execute
-# without error. 
+# without error.
 using NBInclude
 
 @testset "Demo notebook" begin
-    nbinclude(joinpath(@__DIR__, "..", "examples", "jupyter-demo.ipynb"))
+    @nbinclude(joinpath(@__DIR__, "..", "examples", "jupyter-demo.ipynb"))
 end

--- a/test/node.jl
+++ b/test/node.jl
@@ -1,0 +1,3 @@
+@testset "Issue 156" begin
+    @test length(children(node(:div, rand(3, 3)))) == 1
+end

--- a/test/node.jl
+++ b/test/node.jl
@@ -1,3 +1,65 @@
 @testset "Issue 156" begin
     @test length(children(node(:div, rand(3, 3)))) == 1
+
+    n = rand(10, 10) |> dom"div"
+    @test length(children(n)) == 1  # should have one child, and that child should be the given array
+    @test size(first(children(n))) == (10, 10)
 end
+
+# Nodes don't support equality tests currently, so
+# we have to do our own comparison of their contents
+function compare_nodes(n1::Node, n2::Node)
+    (instanceof(n1) == instanceof(n2) &&
+     all(compare_nodes(c1, c2) for (c1, c2) in zip(children(n1), children(n2))) &&
+     props(n1) == props(n2))
+end
+compare_nodes(x1, x2) = x1 == x2
+
+@testset "Setting node fields" begin
+    n1 = node(:div, node(:div, "hello"), node(:div, "world"), foo="bar")
+    n2 = node(:div, node(:div, "hello"), node(:div, "world"), foo="bar")
+
+    n3 = setinstanceof(n1, :ul)
+    # set... methods shouldn't mutate the original object, so
+    # n1 and n2 are still the same
+    @test compare_nodes(n1, n2)
+    # but n1 and n3 are now different
+    @test !compare_nodes(n1, n3)
+    @test instanceof(n3) == WebIO.promote_instanceof(:ul)
+
+    n3 = setchildren(n1, [node(:ul, "list"), node(:li, "item")])
+    # set... methods shouldn't mutate the original object, so
+    # n1 and n2 are still the same
+    @test compare_nodes(n1, n2)
+    # but n1 and n3 are now different
+    @test !compare_nodes(n1, n3)
+    @test length(children(n3)) == 2
+    @test compare_nodes(children(n3)[1], node(:ul, "list"))
+    @test compare_nodes(children(n3)[2], node(:li, "item"))
+
+    n3 = setprops(n1, Dict(:one => 1, :two => 2))
+    # set... methods shouldn't mutate the original object, so
+    # n1 and n2 are still the same
+    @test compare_nodes(n1, n2)
+    # but n1 and n3 are now different
+    @test !compare_nodes(n1, n3)
+    @test props(n3) == Dict(:one => 1, :two => 2)
+end
+
+@testset "Node deprecations" begin
+    # Verify that the deprecated Node(inst, vararg...) constructor
+    # still works (until we delete it in the next release)
+
+    @testset "one child" begin
+        n1 = Node(:div, "hello world")
+        n2 = node(:div, "hello world")
+        @test compare_nodes(n1, n2)
+    end
+    @testset "multiple children" begin
+        n1 = Node(:div, Node(:div, "hello"), Node(:div, "world"), foo="bar")
+        n2 = node(:div, node(:div, "hello"), node(:div, "world"), foo="bar")
+        @test compare_nodes(n1, n2)
+    end
+end
+
+

--- a/test/node.jl
+++ b/test/node.jl
@@ -15,6 +15,11 @@ function compare_nodes(n1::Node, n2::Node)
 end
 compare_nodes(x1, x2) = x1 == x2
 
+@testset "Constructing Nodes from Strings" begin
+    @test compare_nodes(node("div", "hello", "world"),
+                        node(:div, "hello", "world"))
+end
+
 @testset "Setting node fields" begin
     n1 = node(:div, node(:div, "hello"), node(:div, "world"), foo="bar")
     n2 = node(:div, node(:div, "hello"), node(:div, "world"), foo="bar")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,10 +51,10 @@ function capture_plaintext(x)
 end
 
 @testset "plaintext printing" begin
-    @test capture_plaintext(Node(:div)) == "(div)"
-    @test capture_plaintext(Node(:div, Node(:ul))) == "(div\n  (ul))"
-    @test capture_plaintext(Node(:div, Node(:ul, Node(:li, "hello")))) == "(div\n  (ul\n    (li\n      \"hello\")))"
-    @test capture_plaintext(Node(:div, id="foo", class="bar")) == "(div { id=\"foo\" class=\"bar\" })"
+    @test capture_plaintext(node(:div)) == "(div)"
+    @test capture_plaintext(node(:div, node(:ul))) == "(div\n  (ul))"
+    @test capture_plaintext(node(:div, node(:ul, node(:li, "hello")))) == "(div\n  (ul\n    (li\n      \"hello\")))"
+    @test capture_plaintext(node(:div, id="foo", class="bar")) == "(div { id=\"foo\" class=\"bar\" })"
     @test capture_plaintext(dom"ul"(dom"li"("hello"), dom"li"("world"))) == "(ul\n  (li\n    \"hello\")\n  (li\n    \"world\"))"
 end
 
@@ -71,6 +71,7 @@ end
 end
 
 include("communication.jl")
+include("node.jl")
 include("mux-tests.jl")
 include("blink-tests.jl")
 include("util-tests.jl")


### PR DESCRIPTION
This implements the suggestion I made in #156 (and fixes #156 ). 

It's kind of obnoxious to ask users to switch from `Node()` to `node()` in their code, so I'm open to other suggestions. 

For example, instead of doing this, we could keep the vararg `Node()` constructor as-is and replace all our internal usage with a new `_node_internal()` constructor that takes an `AbstractVector` of children. 

But in either case, I think we should be sure that the user-facing constructor has *only* the vararg method, rather than having the ambiguous vararg and Vector methods. 