### PR TITLE
[PR against rd/v0.7-redux] More fixes for 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 yarn.lock
 node_modules
 *.pyc
+deps/build.log
+

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ function install_ijulia_config()
     end
 
     # remove previous config
-    config_str = replace(config_str, Regex("\n?" * BEGIN_MARKER * ".*" * END_MARKER * "\n?", "s"), "")
+    config_str = replace(config_str, Regex("\n?" * BEGIN_MARKER * ".*" * END_MARKER * "\n?", "s") => "")
 
     config_str *= """
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -27,7 +27,7 @@ function lowerdeps(name, imp)
         while true
             if AssetRegistry.isregistered(cur_path) && isdir(cur_path)
                 key = AssetRegistry.getkey(cur_path)
-                url = baseurl[] * key * "/" * replace(path, cur_path, "")
+                url = baseurl[] * key * "/" * replace(path, cur_path => "")
                 break
             end
             cur_path1 = dirname(cur_path)

--- a/src/node.jl
+++ b/src/node.jl
@@ -39,7 +39,7 @@ a javascript string, the html parser will still read them as a closing script
 tag, and thus end the script content prematurely, causing untold woe.
 """
 encode_scripts(htmlstr::String) =
-    replace(htmlstr, "</script>", "</_script>")
+    replace(htmlstr, "</script>" => "</_script>")
 
 function kwargs2props(propkwargs)
     props = Dict{Symbol,Any}(propkwargs)

--- a/src/render.jl
+++ b/src/render.jl
@@ -47,7 +47,7 @@ const mime_order = map(MIME, [ "text/html", "text/latex", "image/svg+xml", "imag
 
 function richest_mime(val)
     for mimetype in mime_order
-        mimewritable(mimetype, val) && return mimetype
+        showable(mimetype, val) && return mimetype
     end
     error("value not writable for any mimetypes")
 end


### PR DESCRIPTION
These weren't covered by WebIO tests but result in errors on 1.0 with RigidBodySim.