### PR TITLE
move widget methods from InteractBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,4 +5,4 @@ Observables 0.0.3
 AssetRegistry
 Requires
 Compat 0.59
-Widgets 0.2.2
+Widgets 0.3.1

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -6,7 +6,7 @@ using Observables
 using Requires
 using AssetRegistry
 using Base64: stringmime
-import Widgets: node
+import Widgets: node, AbstractWidget
 
 abstract type AbstractConnection end
 

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -6,6 +6,7 @@ using Observables
 using Requires
 using AssetRegistry
 using Base64: stringmime
+import Widgets
 import Widgets: node, AbstractWidget
 
 abstract type AbstractConnection end

--- a/src/node.jl
+++ b/src/node.jl
@@ -117,6 +117,16 @@ end
 
 Base.show(io::IO, m::MIME"text/html", x::Observable) = show(io, m, WebIO.render(x))
 
+function Base.show(io::IO, m::MIME"text/html", x::AbstractWidget)
+    if !Widgets.isijulia()
+        show(io, m, WebIO.render(x))
+    else
+        write(io, "<div class='tex2jax_ignore interactbulma'>\n")
+        show(io, m, WebIO.render(x))
+        write(io, "\n</div>")
+    end
+end
+
 ### Utility
 
 descendants_count(t::String) = 0

--- a/src/providers/atom.jl
+++ b/src/providers/atom.jl
@@ -2,10 +2,10 @@ function get_page(opts::Dict=Dict())
     Juno.isactive() ? Juno.Atom.blinkplot() : Window(opts).content
 end
 
-Juno.render(::Juno.PlotPane, n::Union{Node, Scope}) =
+Juno.render(::Juno.PlotPane, n::Union{Node, Scope, AbstractWidget}) =
     (body!(get_page(), n); nothing)
 
-Juno.render(i::Juno.Editor, n::Union{Node, Scope}) =
+Juno.render(i::Juno.Editor, n::Union{Node, Scope, AbstractWidget}) =
     Juno.render(i, Text("$(n.instanceof) Node with $(n._descendants_count) descendent(s)"))
 
 function WebIO.register_renderable(T::Type, ::Val{:atom})

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -14,7 +14,7 @@ struct BlinkConnection <: WebIO.AbstractConnection
     page::Blink.Page
 end
 
-function Blink.body!(p::Blink.Page, x::Union{Node, Scope})
+function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
     wait(p)
 
     bp = AssetRegistry.register(bundlepath)
@@ -31,7 +31,7 @@ function Blink.body!(p::Blink.Page, x::Union{Node, Scope})
     Blink.body!(p, stringmime(MIME"text/html"(), x))
 end
 
-function Blink.body!(p::Blink.Window, x::Union{Node, Scope})
+function Blink.body!(p::Blink.Window, x::Union{Node, Scope, AbstractWidget})
     Blink.body!(p.content, x)
 end
 

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -51,7 +51,7 @@ end
 Base.isopen(p::WebSockConnection) = isopen(p.sock)
 
 
-function Mux.Response(o::Union{Node, Scope})
+function Mux.Response(o::Union{Node, Scope, AbstractWidget})
     key = AssetRegistry.register(joinpath(@__DIR__, "..", "..", "assets"))
     Mux.Response(
         """

--- a/src/render.jl
+++ b/src/render.jl
@@ -107,3 +107,5 @@ function render(obs::Observable)
 
     WebIO.render(scope)
 end
+
+render(w::AbstractWidget) = render(Widgets.layout(w)(w))


### PR DESCRIPTION
I'm moving methods from AbstractWidget here from InteractBase, so that it's easier to keep things in sync when the integration with other packages changes.