### PR TITLE
support abstractobservables

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
 julia 0.7
 JSON 0.7
 FunctionalCollections
-Observables 0.0.3
+Observables 0.2.2
 AssetRegistry
 Requires
 Compat 0.59

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -341,7 +341,7 @@ function ensure_sync(ctx, key)
     end
 end
 
-function onjs(ob::Observable, f)
+function onjs(ob::AbstractObservable, f)
     if haskey(observ_id_dict, ob)
         ctx, key = observ_id_dict[ob]
         ctx = ctx.value

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -16,7 +16,7 @@ export Scope,
        addconnection!
 
 import Compat.Sockets: send
-import Observables: Observable
+import Observables: Observable, AbstractObservable, listeners
 
 """
     ConnectionPool(outbox::Channel, connections::Set{AbstractConnection}=Set())
@@ -93,7 +93,7 @@ Fields:
 mutable struct Scope
     id::AbstractString
     dom::Any
-    observs::Dict{String, Tuple{Observable, Union{Nothing,Bool}}} # bool marks if it is synced
+    observs::Dict{String, Tuple{AbstractObservable, Union{Nothing,Bool}}} # bool marks if it is synced
     private_obs::Set{String}
     systemjs_options
     imports
@@ -173,7 +173,7 @@ function setobservable!(ctx, key, obs; sync=nothing)
 end
 
 # Ask JS to send stuff
-function setup_comm(f, ob::Observable)
+function setup_comm(f, ob::AbstractObservable)
     if haskey(observ_id_dict, ob)
         scope, key = observ_id_dict[ob]
         if !(key in scope.value.private_obs)
@@ -222,7 +222,7 @@ function JSON.lower(x::Scope)
         if sync === nothing
             # by default, we sync if there are any listeners
             # other than the JS back edge
-            sync = any(f-> !isa(f, SyncCallback), ob.listeners)
+            sync = any(f-> !isa(f, SyncCallback), listeners(ob))
         end
         obs_dict[k] = Dict("sync" => sync,
              "value" => ob[],
@@ -335,7 +335,7 @@ end
 function ensure_sync(ctx, key)
     ob = ctx.observs[key][1]
     # have at most one synchronizing handler per observable
-    if !any(x->isa(x, SyncCallback) && x.ctx==ctx, ob.listeners)
+    if !any(x->isa(x, SyncCallback) && x.ctx==ctx, listeners(ob))
         f = SyncCallback(ctx, (msg) -> send(ctx, key, msg))
         on(SyncCallback(ctx, f), ob)
     end


### PR DESCRIPTION
A cleaner way to do #178 : only use the `AbstractObservable` interface in WebIO, so it'll automatically work with all `AbstractObservables`