### PR TITLE
Fix scope imports in iframes with Blink

### DIFF
--- a/assets/webio/dist/bundle.js
+++ b/assets/webio/dist/bundle.js
@@ -2864,7 +2864,7 @@ function doImports(scope, imp) {
         case "js":
             var cfg = {paths: {}}
             cfg.paths[imp.name] = imp.url
-            if (imp.url.slice(0, 4) === "pkg/" || imp.url.slice(0, 5) === "/pkg/") {
+            if (imp.url.slice(0, 12) === "assetserver/" || imp.url.slice(0, 13) === "/assetserver/") {
                 cfg.meta = {};
                 cfg.meta[imp.url] = {authorization: true};
             }

--- a/assets/webio/node.js
+++ b/assets/webio/node.js
@@ -249,7 +249,7 @@ function doImports(scope, imp) {
         case "js":
             var cfg = {paths: {}}
             cfg.paths[imp.name] = imp.url
-            if (imp.url.slice(0, 4) === "pkg/" || imp.url.slice(0, 5) === "/pkg/") {
+            if (imp.url.slice(0, 12) === "assetserver/" || imp.url.slice(0, 13) === "/assetserver/") {
                 cfg.meta = {};
                 cfg.meta[imp.url] = {authorization: true};
             }

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -30,6 +30,7 @@ setup_provider(s::Union{Symbol, AbstractString}) = setup_provider(Val(Symbol(s))
 export setup_provider
 
 const baseurl = Ref{String}("")
+const bundlepath = joinpath(@__DIR__, "..", "assets", "webio", "dist", "bundle.js")
 
 function setbaseurl!(str)
     baseurl[] = str

--- a/src/iframe.jl
+++ b/src/iframe.jl
@@ -2,7 +2,8 @@ export iframe
 
 function iframe(dom)
     str = stringmime("text/html", dom)
-
+    key = AssetRegistry.register(bundlepath)
+    bundle_url = string(baseurl[], key)
     s = Scope()
     s.dom = node(:div,
                  node(:iframe, id="ifr", style=Dict("width"=>"100%"),
@@ -15,22 +16,15 @@ function iframe(dom)
             var doc = frame.contentDocument
             var win = frame.contentWindow
 
-            // Determine if we're running on a Jupyter hosting service
-            // that requires a base URL when retrieving assets
-            var curMatch =
-                window.location.href
-                .match(/(.*?)\/notebooks\/.*\.ipynb/);
-            curMatch = curMatch ||
-                window.location.href
-                .match(/(.*?)\/apps\/.*\.ipynb/);
-            if (curMatch) {
-                var base = doc.createElement("base");
-                base.setAttribute("href", curMatch[1] + '/');
-                doc.head.appendChild(base);
-            }
+            // Ensure that the iframe's baseURI matches the baseURI of the
+            // outer document. This is necessary to resolve
+            // https://github.com/JuliaGizmos/WebIO.jl/issues/167
+            var base = doc.createElement("base");
+            base.setAttribute("href", document.baseURI);
+            doc.head.appendChild(base);
 
             var webio = doc.createElement("script")
-            webio.src = "pkg/WebIO/webio/dist/bundle.js"
+            webio.src = $bundle_url
             var parent = window
 
             function resizeIframe() {

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -1,9 +1,6 @@
 using AssetRegistry
 using Base64: stringmime
 
-const bundlepath = joinpath(dirname(@__FILE__), "..", "..",
-                            "assets", "webio", "dist",
-                            "bundle.js")
 const blinksetup = joinpath(dirname(@__FILE__), "..", "..",
                             "assets", "providers",
                             "blink_setup.js")
@@ -17,7 +14,7 @@ end
 function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
     wait(p)
 
-    bp = AssetRegistry.register(bundlepath)
+    bp = AssetRegistry.register(WebIO.bundlepath)
     bs = AssetRegistry.register(blinksetup)
 
     Blink.loadjs!(p, bp)


### PR DESCRIPTION
Fixes #167 
Fixes https://github.com/rdeits/MeshCat.jl/issues/49

The root cause turned out to be that the `iframe` document in Blink has its `baseURI` attribute set to `"about:blank"` which causes SystemJS to...I don't know. Do something stupid. 

I'm not sure, but I suspect this error came with the upgrade to electron 2.0, since I can't think of anything in our code that would have broken this. Firefox doesn't have the problem (it assigns the same baseURI to the iframe as the parent document). 

To resolve it, I'm just adding the `base` tag that matches the `base` of the containing document, which should force Blink/electron to do the same thing that Firefox does. 

I also removed the base URL detection logic from `iframe.jl`. I think that's now obsolete with the new `WebIO.baseurl[]`, correct? 

