### PR TITLE
allow custom host

### DIFF
--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -4,14 +4,12 @@ using Sockets
 using Base64: stringmime
 export webio_serve
 
-webio_serve(app, port::Integer) = webio_serve(app, Sockets.localhost, port)
-
 """
     webio_serve(app, port=8000)
 
 Serve a Mux app which might return a WebIO node.
 """
-function webio_serve(app, host=Sockets.localhost, port=8000)
+function webio_serve(app, args...)
     http = Mux.App(Mux.mux(
         Mux.defaults,
         app,
@@ -25,7 +23,7 @@ function webio_serve(app, host=Sockets.localhost, port=8000)
         Mux.notfound(),
     ))
 
-    Mux.serve(http, websock, host, port)
+    Mux.serve(http, websock, args...)
 end
 
 struct WebSockConnection <: WebIO.AbstractConnection

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -4,12 +4,14 @@ using Sockets
 using Base64: stringmime
 export webio_serve
 
+webio_serve(app, port::Integer) = webio_serve(app, Sockets.localhost, port)
+
 """
     webio_serve(app, port=8000)
 
 Serve a Mux app which might return a WebIO node.
 """
-function webio_serve(app, port=8000)
+function webio_serve(app, host=Sockets.localhost, port=8000)
     http = Mux.App(Mux.mux(
         Mux.defaults,
         app,
@@ -23,7 +25,7 @@ function webio_serve(app, port=8000)
         Mux.notfound(),
     ))
 
-    Mux.serve(http, websock, port)
+    Mux.serve(http, websock, host, port)
 end
 
 struct WebSockConnection <: WebIO.AbstractConnection


### PR DESCRIPTION
This is a companion PR to https://github.com/JuliaWeb/Mux.jl/pull/70 to allow the user passing a host different than `localhost`. 

~I'm actually curious (both here and in https://github.com/JuliaWeb/Mux.jl/pull/70 ) whether we want positional of keyword arguments for this. One advantage of keyword is that we could allow to pass several `app` at the same time to `webio_serve` which is pretty useful for multi page applications.~

Actually there's never any need to splat as for serving many pages one can use the Mux infrastructure:

`webio_serve(Mux.stack(pages...), host, port)`

so we should not do keyword argument and stay consistent with Mux and HTTP I think.