### PR TITLE
use a private RNG to generate scope IDs

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -1,7 +1,12 @@
 using FunctionalCollections
+using Random: MersenneTwister
 using UUIDs
 
-newid(prefix) = string(prefix, '-', uuid4())
+const newid = let rng = MersenneTwister()
+    function(prefix)
+        string(prefix, '-', uuid4(rng))
+    end
+end
 
 _pvec(x::PersistentVector) = x
 _pvec(x::AbstractArray) = pvec(x)

--- a/test/util-tests.jl
+++ b/test/util-tests.jl
@@ -1,7 +1,8 @@
 using Test
 using WebIO
+using Random
 
-import WebIO: kebab2camel, camel2kebab
+using WebIO: kebab2camel, camel2kebab, newid
 
 @testset "kebabs and camels" begin
     kebabstrs = ["vue-instance-17-node-18", "bum-two-three", "silly nanny", "nanny"]
@@ -17,3 +18,20 @@ import WebIO: kebab2camel, camel2kebab
         @test camelstrs[i] == kebabstrs[i] || camelstrs[i] == kebab_also_trues[i]
     end
 end
+
+@testset "Scope ID uniqueness" begin
+    prefix = ""
+    # Verify that sequential IDs are not the same
+    for i in 1:100
+        @test newid(prefix) != newid(prefix)
+    end
+
+    # Verify that resetting the global random seed does not result in
+    # scopes with the same ID
+    Random.seed!(1)
+    id1 = newid(prefix)
+    Random.seed!(1)
+    id2 = newid(prefix)
+    @test id1 != id2
+end
+


### PR DESCRIPTION
this ensures that seeding the global RNG cannot result in scopes with
duplicate IDs