### PR TITLE
Delay _setup_scope until after onimport

### DIFF
--- a/assets/webio/node.js
+++ b/assets/webio/node.js
@@ -324,8 +324,6 @@ function createScope(options, data) {
 
     scope.promises.connected = new Promise(function (accept, reject) {
         WebIO.onConnected(function () {
-            // internal message to notify julia
-            WebIO.send(scope, "_setup_scope", {});
             accept(scope);
         })
     })
@@ -334,13 +332,20 @@ function createScope(options, data) {
         appendChildren(scope, fragment, data.children);
     })
 
+    var callbackPromise = new Promise(function (acc, rej) {acc()}) // always accept
     if (handlers._promises !== undefined &&
         handlers._promises["importsLoaded"]){
         var onimportfns = handlers._promises["importsLoaded"]
-        depsPromise.then(function(alldeps){
+        callbackPromise = depsPromise.then(function(alldeps){
             onimportfns.map(function (f){ f.apply(scope, alldeps) })
         })
     }
+
+    Promise.all([scope.promises.connected, callbackPromise]).then(function () {
+        // internal message to notify julia that
+        // the scope can now receive messages
+        WebIO.send(scope, "_setup_scope", {})
+    })
 
     return fragment;
 }


### PR DESCRIPTION
If a Scope has messages in the outbox before being displayed, it would start to accept them before `onimport` callback is run.

This was not working well with Plots's approach of starting with an empty plot and then building the pieces in.

@sglyon let me know if this helps.