### PR TITLE
Fix the `Base.warn_once`

### DIFF
--- a/src/imports.jl
+++ b/src/imports.jl
@@ -10,7 +10,7 @@ end
 
 function path2url(path::AbstractString)
     if startswith(path, "/pkg/")
-        Base.warn_once("/pkg/ URLs are deprecated, load files with their absolute path in Scope")
+        @warn("/pkg/ URLs are deprecated, load files with their absolute path in Scope")
         return path
     elseif isfile(abspath(path))
         path = abspath(path)


### PR DESCRIPTION
Incompatible with 1.0