### PR TITLE
reduce piracy to Widgets

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,4 +5,4 @@ Observables 0.2.2
 AssetRegistry
 Requires
 Compat 0.59
-Widgets 0.3.1
+Widgets 0.5.1

--- a/src/node.jl
+++ b/src/node.jl
@@ -142,7 +142,6 @@ end
 
 Base.show(io::IO, m::MIME"text/html", x::Observable) = show(io, m, WebIO.render(x))
 Base.show(io::IO, m::WEBIO_NODE_MIME, x::Union{Observable, AbstractWidget}) = show(io, m, WebIO.render(x))
-Base.show(io::IO, m::MIME"text/html", x::AbstractWidget) = show(io, m, WebIO.render(x))
 
 ### Utility
 

--- a/src/providers/blink.jl
+++ b/src/providers/blink.jl
@@ -12,7 +12,8 @@ struct BlinkConnection <: WebIO.AbstractConnection
     page::Blink.Page
 end
 
-function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
+Blink.body!(p::Blink.Page, x::AbstractWidget) = Blink.body!(p, Widgets.render(x))
+function Blink.body!(p::Blink.Page, x::Union{Node, Scope})
     wait(p)
 
     bs = AssetRegistry.register(blinksetup)
@@ -26,7 +27,8 @@ function Blink.body!(p::Blink.Page, x::Union{Node, Scope, AbstractWidget})
     Blink.body!(p, stringmime(MIME"text/html"(), x))
 end
 
-function Blink.body!(p::Blink.Window, x::Union{Node, Scope, AbstractWidget})
+Blink.body!(p::Blink.Window, x::AbstractWidget) = Blink.body!(p, Widgets.render(x))
+function Blink.body!(p::Blink.Window, x::Union{Node, Scope})
     Blink.body!(p.content, x)
 end
 

--- a/src/providers/mux.jl
+++ b/src/providers/mux.jl
@@ -50,8 +50,8 @@ end
 
 Base.isopen(p::WebSockConnection) = isopen(p.sock)
 
-
-function Mux.Response(o::Union{Node, Scope, AbstractWidget})
+Mux.Response(o::AbstractWidget) = Mux.Response(Widgets.render(o))
+function Mux.Response(o::Union{Node, Scope})
     key = AssetRegistry.register(joinpath(@__DIR__, "..", "..", "packages/mux-provider/dist"))
     Mux.Response(
         """

--- a/src/render.jl
+++ b/src/render.jl
@@ -171,4 +171,4 @@ function render(obs::Observable)
     return WebIO.render(scope)
 end
 
-render(w::AbstractWidget) = render(Widgets.layout(w)(w))
+render(w::AbstractWidget) = render(Widgets.render(w))


### PR DESCRIPTION
The idea with the current Widgets design is that all "graphical things" just forward stuff to `Widgets.render(x)` (separate from `WebIO.render`), so that packages different than WebIO can use `Widgets` (the plan is to add a Makie backend: https://github.com/JuliaPlots/AbstractPlotting.jl/pull/88). So basically for a Makie `Widget`, `Widgets.render(wdg)` would return a Makie object that would then be displayed with the Makie pipeline. The Mux and Blink methods should live in Mux and Blink to avoid type piracy but I thought we can move them when we move the rest.