### PR TITLE
Simplify RPC API.

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,5 @@
 Blink 0.8.0
+DataStructures
 Mux 0.5.1
 IJulia
 NBInclude 2.0.0

--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -23,20 +23,8 @@ function with_timeout(f::Function, timeout)
     take!(c)
 end
 
-"""
-    open_window()
-
-Open a window, optionally showing it when the BLINK_DEBUG environment variable
-is set (to allow for seeing what happens in the Electron console).
-"""
-function open_window()
-    if haskey(ENV, "BLINK_DEBUG")
-        w = Window(Dict(:show => true))
-        @js w localStorage.debug = "*"
-        opentools(w)
-        return w
-    end
-    return Window(Dict(:show => false))
+if !(@isdefined open_window)
+    include("./test-utils.jl")
 end
 
 # IMPORTANT: Cannot open Window's inside of @testsets.

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -1,0 +1,29 @@
+export DummyConnection
+
+using Sockets
+using DataStructures
+
+struct DummyConnection <: WebIO.AbstractConnection
+    inbox::Queue{Any}
+
+    DummyConnection() = new(Queue{Any}())
+end
+
+Base.take!(c::DummyConnection) = dequeue!(c.inbox)
+Sockets.send(c::DummyConnection, data) = enqueue!(c.inbox, data)
+
+"""
+    open_window()
+
+Open a window, optionally showing it when the BLINK_DEBUG environment variable
+is set (to allow for seeing what happens in the Electron console).
+"""
+function open_window()
+    if haskey(ENV, "BLINK_DEBUG")
+        w = Window(Dict(:show => true))
+        @js w localStorage.debug = "*"
+        opentools(w)
+        return w
+    end
+    return Window(Dict(:show => false))
+end


### PR DESCRIPTION
Simplifies RPC API. You can now interpolate any Julia function.

```julia
js"""
async function() {
    // Note: without `await`, this executes asynchronously.
    // The println **should** start execution before the abs, but the order of completion
    // is absolutely not guaranteed (except in IJulia, due to the fact that comms are
    // synchronous).
    $println("Print to Julia's stdout.");
    console.log(await $abs(-3));
}
"""
```

Equivalently, using `Promise.then` rathern than `async` functions, you can write this.
```julia
js"""
function() {
    $abs(-3).then((result) => console.log(result));
}
```

Requesting review from @shashi.