### PR TITLE
Deprecate custom scope ids

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -2233,7 +2233,7 @@
 				"@phosphor/messaging": "^1.2.2",
 				"@phosphor/widgets": "^1.6.0",
 				"@types/debug": "^4.1.2",
-				"@webio/webio": "file:webio",
+				"@webio/webio": "^0.8.3",
 				"debug": "^4.1.1"
 			}
 		},
@@ -4484,12 +4484,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4504,17 +4506,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4631,7 +4636,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4643,6 +4649,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4657,6 +4664,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4664,12 +4672,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4688,6 +4698,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4768,7 +4779,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4780,6 +4792,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4901,6 +4914,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",

--- a/src/render.jl
+++ b/src/render.jl
@@ -118,7 +118,7 @@ function observable_to_scope(obs::Observable)
         )
         map!(output, obs) do value
             if !isa(value, Node)
-                @warn "A rendered observable (scope.id=$(scope.id), obs.id=$(obs.id)) changed from a WebIO node to $(typeof(value))."
+                @warn "A rendered observable (scopeid=$(scopeid(scope)), obs.id=$(obs.id)) changed from a WebIO node to $(typeof(value))."
                 return nothing
             end
             return value

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -17,27 +17,65 @@ export Scope,
 import Compat.Sockets: send
 import Observables: Observable, AbstractObservable, listeners
 
+# bool marks if it is synced
+const ObsDict = Dict{String, Tuple{AbstractObservable, Union{Nothing,Bool}}}
+
 mutable struct Scope
-    id::AbstractString
     dom::Any
-    observs::Dict{String, Tuple{AbstractObservable, Union{Nothing,Bool}}} # bool marks if it is synced
+    observs::ObsDict
     private_obs::Set{String}
-    systemjs_options
+    systemjs_options::Any
     # This should be an array of scopes, but there currently exist some circular
     # relationships between imports and scopes.
-    imports::AbstractArray
+    imports::Vector{Asset}
     # A collection of handler functions associated with various observables in
     # this scope. Of the form
     # "observable-name" => ["array", "of", "JS", "strings"]
     # where each JS-string is a function that is invoked when the observable
     # changes.
-    jshandlers
+    jshandlers::Any
     pool::ConnectionPool
 
     mount_callbacks::Vector{JSString}
+
+    function Scope(
+            dom::Any,
+            observs::ObsDict, # bool marks if it is synced
+            private_obs::Set{String},
+            systemjs_options::Any,
+            imports::Vector{Asset},
+            jshandlers::Any,
+            pool::ConnectionPool,
+            mount_callbacks::Vector{JSString}
+        )
+        scope = new(
+            dom, observs, private_obs,
+            systemjs_options, imports, jshandlers, pool,
+            mount_callbacks
+        )
+        register!(scope)
+        return scope
+    end
 end
 
-const scopes = Dict{String, Scope}()
+# Need to use String for correct json javascript serialization -.-
+scopeid(x::Scope) = string(objectid(x))
+
+const global_scope_registry = Dict{String, Scope}()
+
+function register!(scope::Scope)
+    global_scope_registry[scopeid(scope)] = scope
+end
+
+function deregister!(scope::Scope)
+    delete!(global_scope_registry, scopeid(scope))
+end
+
+function lookup_scope(uuid::String)
+    get(global_scope_registry, uuid) do
+        error("Could not find scope $(uuid)")
+    end
+end
 
 """
     Scope(<keyword arguments>)
@@ -62,34 +100,23 @@ myscope = Scope(
 ```
 """
 function Scope(;
-        id::String=newid("scope"),
-        dom=dom"span"(),
-        outbox::Channel=Channel{Any}(Inf),
-        observs::Dict=Dict(),
-        private_obs::Set{String}=Set{String}(),
-        dependencies=nothing,
-        systemjs_options=nothing,
-        imports=nothing,
-        jshandlers::Dict=Dict(),
-        mount_callbacks::Vector{JSString}=Vector{JSString}(),
+        id::String = "scope",
+        dom = dom"span"(),
+        outbox::Channel = Channel{Any}(Inf),
+        observs::Dict = ObsDict(),
+        private_obs::Set{String} = Set{String}(),
+        systemjs_options = nothing,
+        imports = Asset[],
+        jshandlers::Dict = Dict(),
+        mount_callbacks::Vector{JSString} = JSString[],
     )
-
-    if dependencies !== nothing
-        @warn("dependencies keyword argument is deprecated, use WebAsset instead.", maxlog=1)
-        imports = dependencies
-    end
-
-    imports = (imports == nothing) ? [] : [Asset(i) for i in imports]
-
-    if haskey(scopes, id)
-        @warn("A scope by the id $id already exists. Overwriting.")
-    end
-
+    imports = Asset[Asset(i) for i in imports]
     pool = ConnectionPool(outbox)
-
-    scopes[id] = Scope(id, dom, observs, private_obs, systemjs_options, imports, jshandlers, pool, mount_callbacks)
+    return Scope(
+        dom, observs, private_obs, systemjs_options,
+        imports, jshandlers, pool, mount_callbacks
+    )
 end
-Base.@deprecate Scope(id::AbstractString; kwargs...) Scope(; id=id, kwargs...)
 
 (w::Scope)(arg) = (w.dom = arg; w)
 Base.wait(scope::Scope) = ensure_connection(scope.pool)
@@ -123,7 +150,7 @@ const observ_id_dict = WeakKeyDict()
 function setobservable!(ctx, key, obs; sync=nothing)
     key = string(key)
     if haskey(ctx.observs, key)
-        @warn("An observable named $key already exists in scope $(ctx.id).
+        @warn("An observable named $key already exists in scope $(scopeid(ctx)).
              Overwriting.")
     end
 
@@ -171,13 +198,11 @@ function Observable(ctx::Scope, key, val::T; sync=nothing) where {T}
     Observable{T}(ctx, key, val; sync=sync)
 end
 
-const Observ = Observable
-
-function JSON.lower(x::Scope)
+function JSON.lower(scope::Scope)
     obs_dict = Dict()
-    for (k, ob_) in x.observs
+    for (k, ob_) in scope.observs
         ob, sync = ob_
-        if k in x.private_obs
+        if k in scope.private_obs
             continue
         end
         if sync === nothing
@@ -185,17 +210,20 @@ function JSON.lower(x::Scope)
             # other than the JS back edge
             sync = any(f-> !isa(f, SyncCallback), listeners(ob))
         end
-        obs_dict[k] = Dict("sync" => sync,
-             "value" => ob[],
-             "id" => obsid(ob))
+        obs_dict[k] = Dict(
+            "sync" => sync,
+            "value" => ob[],
+            "id" => obsid(ob)
+        )
     end
     Dict(
-        "id" => x.id,
-        "systemjs_options" => x.systemjs_options,
-        "imports" => lowerassets(x.imports),
-        "handlers" => x.jshandlers,
-        "mount_callbacks" => x.mount_callbacks,
-        "observables" => obs_dict)
+        "id" => scopeid(scope),
+        "systemjs_options" => scope.systemjs_options,
+        "imports" => lowerassets(scope.imports),
+        "handlers" => scope.jshandlers,
+        "mount_callbacks" => scope.mount_callbacks,
+        "observables" => obs_dict
+    )
 end
 
 function render(s::Scope)
@@ -210,10 +238,10 @@ style message; no response or acknowledgement is expected.
 """
 function send_command(scope::Scope, command, data::Pair...)
     message = Dict(
-      "type" => "command",
-      "command" => command,
-      "scope" => scope.id,
-      data...
+        "type" => "command",
+        "command" => command,
+        "scope" => scopeid(scope),
+        data...
     )
     send(scope.pool, message)
     nothing
@@ -229,7 +257,9 @@ send_update_observable(scope::Scope, name::AbstractString, value) = send_command
     "value" => value,
 )
 
-send_request(scope::Scope, request, data::Pair...) = send_request(scope.pool, request, "scope" => scope.id, data...)
+function send_request(scope::Scope, request, data::Pair...)
+    send_request(scope.pool, request, "scope" => scopeid(scope), data...)
+end
 
 macro evaljs(ctx, expr)
     @warn("@evaljs is deprecated, use evaljs function instead")
@@ -276,14 +306,16 @@ function set_nosync(ob, val)
 end
 
 const lifecycle_commands = ["scope_created"]
+
 function dispatch(ctx, key, data)
     if haskey(ctx.observs, string(key))
         # this message has come from the browser
         # so don't update the browser back!
         set_nosync(ctx.observs[key][1], data)
     else
-        key ∈ lifecycle_commands ||
-            @warn("$key does not have a handler for scope id $(ctx.id)")
+        if !(key in lifecycle_commands)
+            @warn("$key does not have a handler for scope id $(scopeid(ctx))")
+        end
     end
 end
 

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -53,9 +53,17 @@ mutable struct Scope
             systemjs_options, imports, jshandlers, pool,
             mount_callbacks
         )
-        register!(scope)
+        register_scope!(scope)
         return scope
     end
+end
+
+function Base.getproperty(scope::Scope, property::Symbol)
+    if property === :id
+        Base.depwarn("Accessing scope.id is deprecated; use scopeid(scope) instead.", :webio_scope_id)
+        return scopeid(scope)
+    end
+    return getfield(scope, property)
 end
 
 # Need to use String for correct json javascript serialization -.-
@@ -63,11 +71,11 @@ scopeid(x::Scope) = string(objectid(x))
 
 const global_scope_registry = Dict{String, Scope}()
 
-function register!(scope::Scope)
+function register_scope!(scope::Scope)
     global_scope_registry[scopeid(scope)] = scope
 end
 
-function deregister!(scope::Scope)
+function deregister_scope!(scope::Scope)
     delete!(global_scope_registry, scopeid(scope))
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,8 +1,14 @@
 using FunctionalCollections
-
+using Random
 _pvec(x::PersistentVector) = x
 _pvec(x::AbstractArray) = pvec(x)
 
+const newid = let rng = MersenneTwister()
+    function (prefix)
+        Base.depwarn("newid(prefix) is deprecated. Scopes don't need this anymore. To get the scope's id, use scopeid(scope)", :newid)
+        string(prefix, '-', uuid4(rng))
+    end
+end
 # b can be array of pairs / kwargs etc.
 function recmerge!(a, b, f=recmerge!)
     for (k, v) in b

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,12 +1,4 @@
 using FunctionalCollections
-using Random: MersenneTwister
-using UUIDs
-
-const newid = let rng = MersenneTwister()
-    function(prefix)
-        string(prefix, '-', uuid4(rng))
-    end
-end
 
 _pvec(x::PersistentVector) = x
 _pvec(x::AbstractArray) = pvec(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,11 @@
 using WebIO
 using Test
 using Sockets
+import WebIO: DOM, instanceof
 
 # Always bundle first so we're testing against latest version of WebIO JS.
 include("bundling.jl")
 
-import WebIO: DOM, instanceof
 @testset "node" begin
 
     @test dom"div"().children == []

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using Sockets
 
 # Always bundle first so we're testing against latest version of WebIO JS.
-#include("bundling.jl")
+include("bundling.jl")
 
 import WebIO: DOM, instanceof
 @testset "node" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 using Sockets
 
 # Always bundle first so we're testing against latest version of WebIO JS.
-include("bundling.jl")
+#include("bundling.jl")
 
 import WebIO: DOM, instanceof
 @testset "node" begin

--- a/test/util-tests.jl
+++ b/test/util-tests.jl
@@ -2,7 +2,7 @@ using Test
 using WebIO
 using Random
 
-using WebIO: kebab2camel, camel2kebab, newid
+using WebIO: kebab2camel, camel2kebab
 
 @testset "kebabs and camels" begin
     kebabstrs = ["vue-instance-17-node-18", "bum-two-three", "silly nanny", "nanny"]
@@ -18,20 +18,3 @@ using WebIO: kebab2camel, camel2kebab, newid
         @test camelstrs[i] == kebabstrs[i] || camelstrs[i] == kebab_also_trues[i]
     end
 end
-
-@testset "Scope ID uniqueness" begin
-    prefix = ""
-    # Verify that sequential IDs are not the same
-    for i in 1:100
-        @test newid(prefix) != newid(prefix)
-    end
-
-    # Verify that resetting the global random seed does not result in
-    # scopes with the same ID
-    Random.seed!(1)
-    id1 = newid(prefix)
-    Random.seed!(1)
-    id2 = newid(prefix)
-    @test id1 != id2
-end
-


### PR DESCRIPTION
The scope ID should 100% internal, and no one should be able to mutate it... Or use it to name the scope. 
This change should be making sure of this. 
If packages actually used the ID to name the scopes, we should give an alternate option to name scopes, and not mix it with the ID.