### PR TITLE
Defer building JupyterLab bundle

### DIFF
--- a/deps/jupyter.jl
+++ b/deps/jupyter.jl
@@ -129,8 +129,9 @@ Jupyter Lab and WebIO.
 """
 function install_jupyter_labextension(jupyter::Cmd=find_jupyter_cmd())
     install_jupyter_serverextension()
-    run(`$jupyter labextension link $WEBIO_CORE_PACKAGE_PATH`)
-    run(`$jupyter labextension install $JUPYTER_LAB_PROVIDER_PATH`)
+    run(`$jupyter labextension link --no-build $WEBIO_CORE_PACKAGE_PATH`)
+    run(`$jupyter labextension install --no-build $JUPYTER_LAB_PROVIDER_PATH`)
+    run(`$jupyter lab build`)
 end
 
 


### PR DESCRIPTION
Thanks to @alecloudenback (comment on #294). Hopefully this fixes your issue.

This should also speed up the install time because previously the JupyterLab bundle was rebuild twice (once after the `labextension link` and once after the `labextension install` steps).