### PR TITLE
Fix bad deprecation for Scope constructor.

### DIFF
--- a/src/scope.jl
+++ b/src/scope.jl
@@ -146,7 +146,7 @@ function Scope(id; kwargs...)
         "Scope(id; kwargs...) is deprecated, use Scope(kwargs...) instead.",
         :webio_scope_id_positional_arg,
     )
-    return Scope(kwargs...)
+    return Scope(; kwargs...)
 end
 
 (w::Scope)(arg) = (w.dom = arg; w)

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -4,4 +4,8 @@ using Test
 @testset "Scope id deprecations" begin
     @test_deprecated Scope("manual-ids-are-deprecated")
     @test_deprecated Scope(; id="still-deprecated")
+
+    # Make sure that non-deprecated arguments are still handled as expected.
+    # This surfaced in https://github.com/JuliaGizmos/Interact.jl/issues/315.
+    @test_deprecated !isempty(Scope("foo"; imports=["foo.js"]).imports)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaGizmos/Interact.jl/issues/315.

The problematic bit of code seems to be [this line in Knockout.jl](https://github.com/JuliaGizmos/Knockout.jl/blob/1dd70973445e3ca1bfb8c98e3111ef18979e599b/src/Knockout.jl#L28-L30).