### PR TITLE
Fix memory leak in ConnectionPool when connections are closed.

### DIFF
--- a/src/scope.jl
+++ b/src/scope.jl
@@ -85,8 +85,6 @@ const global_scope_registry = Dict{String, Scope}()
 
 function register_scope!(scope::Scope)
     global_scope_registry[scopeid(scope)] = scope
-    for conn in connections(scope.pool)
-        conn_scope_map[]
 end
 
 function deregister_scope!(scope::Scope)

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -85,6 +85,8 @@ const global_scope_registry = Dict{String, Scope}()
 
 function register_scope!(scope::Scope)
     global_scope_registry[scopeid(scope)] = scope
+    for conn in connections(scope.pool)
+        conn_scope_map[]
 end
 
 function deregister_scope!(scope::Scope)
@@ -119,7 +121,7 @@ myscope = Scope(
 """
 function Scope(;
         dom = dom"span"(),
-        outbox::Channel = Channel{Any}(Inf),
+        outbox::Union{Channel, Nothing} = nothing,
         observs::Dict = ObsDict(),
         private_obs::Set{String} = Set{String}(),
         systemjs_options = nothing,
@@ -137,7 +139,7 @@ function Scope(;
         )
     end
     imports = Asset[Asset(i) for i in imports]
-    pool = ConnectionPool(outbox)
+    pool = outbox !== nothing ? ConnectionPool(outbox) : ConnectionPool()
     return Scope(
         dom, observs, private_obs, systemjs_options,
         imports, jshandlers, pool, mount_callbacks

--- a/test/observable-node.jl
+++ b/test/observable-node.jl
@@ -3,7 +3,7 @@ using Observables
 using Test
 using JSExpr
 
-@testset "Afljashfjlsahf" begin
+@testset "Observables with nodes" begin
     w = Scope()
     counter = Observable(w, "counter", 0)
     domnode = map(x -> dom"span"("Counter is $counter[]!"), counter)


### PR DESCRIPTION
Ping @shashi.

tl;dr: when connections were being closed, we would buffer messages in the outbox forever. This is a problem when the outbox contains something like a reasonably sized image. Now, we drop messages if there are no connections (this is probably fine, especially once we implement allowing the frontend to pull the latest values of the observables) and is necessary to fix this issue. It should also be addressed in part by implementing scope reasoning.

Bug report source: https://github.com/JuliaGizmos/Interact.jl/issues/299