### PR TITLE
Fix sending commands to multiple frontends.

### DIFF
--- a/test/bundling.jl
+++ b/test/bundling.jl
@@ -2,5 +2,9 @@ using WebIO
 using Test
 
 @testset "Build JavaScript" begin
+    if haskey(ENV, "WEBIO_SKIP_BUNDLEJS")
+        @info "Skipping building JavaScript."
+        return
+    end
     WebIO.bundlejs()
 end

--- a/test/multiple-connections.jl
+++ b/test/multiple-connections.jl
@@ -1,0 +1,39 @@
+using WebIO
+using Test
+using Blink, JSExpr
+
+if !(@isdefined open_window)
+    include("./test-utils.jl")
+end
+
+@testset "Test observable updates are sent to all connections" begin
+    w1, w2 = open_window(), open_window()
+    s = Scope(
+        dom=node(
+            :p,
+            "initial",
+            attributes=Dict(
+                "data-testid" => "foobar",
+            ),
+        ),
+    )
+    obs = Observable{Any}(s, "obs", "")
+    onjs(obs, @js function (value)
+        _webIOScope.dom.querySelector("[data-testid=foobar]").innerText = value
+    end)
+
+    body!(w1, s)
+    body!(w2, s)
+    # Sleep to allow the JS to execute.
+    sleep(0.25)
+
+    value = (w) -> @js w document.querySelector("[data-testid=foobar]").innerText
+    @test value(w1) == "initial"
+    @test value(w2) == "initial"
+
+    obs[] = "updated"
+    # Sleep to allow the JS to execute.
+    sleep(0.25)
+    @test value(w1) == "updated"
+    @test value(w2) == "updated"
+end


### PR DESCRIPTION
This also reworks the way that new channels are added to a scope to work more
synchronously and avoid some race conditions.

Fixes #337 .