### PR TITLE
Use an unbounded channel for each connection instead of an outbox

### DIFF
--- a/src/connection.jl
+++ b/src/connection.jl
@@ -5,11 +5,6 @@ export AbstractConnection
 abstract type AbstractConnection end
 
 """
-The maximum number of messages to allow into the outbox.
-"""
-const DEFAULT_OUTBOX_LIMIT = 32
-
-"""
     ConnectionPool([outbox[, connections]])
 
 Manages the distribution of messages from the `outbox` channel to a set of
@@ -18,46 +13,56 @@ and sends each message to every connection in the pool. Any closed connections
 are automatically removed from the pool.
 """
 struct ConnectionPool
-    outbox::Channel
-    connections::Set{AbstractConnection}
+    connections::Dict{AbstractConnection, Channel{Any}}
     condition::Condition
 end
 
 function ConnectionPool(
-        outbox::Channel = Channel{Any}(DEFAULT_OUTBOX_LIMIT),
-        connections=Set{AbstractConnection}(),
+        connections=Dict()
 )
     pool = ConnectionPool(
-        outbox,
         connections,
         Condition(),
     )
-
-    # Catch errors here, otherwise they are lost to the void.
-    @async try
-        process_messages(pool)
-    catch exc
-        @error(
-            "An error ocurred in the while processing messages from a "
-                * "ConnectionPool.",
-            exception=exc,
-        )
-    end
-
     return pool
 end
 
 function addconnection!(pool::ConnectionPool, conn::AbstractConnection)
-    push!(pool.connections, conn)
-    notify(pool)
+    if !(conn in keys(pool.connections))
+        let outbox = Channel{Any}(Inf)
+            pool.connections[conn] = outbox
+            @async begin
+                while true
+                    # Catch errors here, otherwise they are lost to the void.
+                    try
+                        msg = take!(outbox)
+                        if isopen(conn)
+                            send(conn, msg)
+                        else
+                            @info "Connection is not open." conn
+                            break
+                        end
+                    catch exc
+                        @error(
+                            "An error ocurred in the while processing messages from a ConnectionPool.",
+                            exception=exc,
+                        )
+                        break
+                    end
+                end
+                println("Deleting: $conn")
+                delete!(pool.connections, conn)
+            end
+        end
+        notify(pool)
+    end
 end
 
 function Sockets.send(pool::ConnectionPool, msg)
-    if length(pool.outbox.data) >= pool.outbox.sz_max
-        # TODO: https://github.com/JuliaGizmos/WebIO.jl/issues/343
-        return
+    ensure_connection(pool)
+    for channel in values(pool.connections)
+        put!(channel, msg)
     end
-    put!(pool.outbox, msg)
 end
 
 """
@@ -74,57 +79,3 @@ end
 
 Base.wait(pool::ConnectionPool) = ensure_connection(pool)
 Base.notify(pool::ConnectionPool) = notify(pool.condition)
-
-"""
-    process_messages(pool)
-
-Process messages in a connection pool outbox and send them to all connected
-frontends.
-
-This function should be run as a task (it will block forever otherwise).
-"""
-function process_messages(pool::ConnectionPool)
-    ensure_connection(pool)
-    while true
-        msg = take!(pool.outbox)
-        @sync begin
-            # This may result in sending to no connections, but we're okay with
-            # that because we'll just get the next value of the observable
-            # (messages are fire and forget - WebIO makes no guarantees that
-            # messages are ever actually delivered).
-            for connection in pool.connections
-                @async send_message(pool, connection, msg)
-            end
-        end
-    end
-end
-
-"""
-    send_message(pool, connection, msg)
-
-Send a message to an individual connection within a pool, handling errors and
-deleting the connection from the pool if necessary.
-"""
-function send_message(
-        pool::ConnectionPool,
-        connection::AbstractConnection,
-        msg,
-)::Nothing
-    try
-        if isopen(connection)
-            send(connection, msg)
-        else
-            @info "Connection is not open." connection
-            delete!(pool.connections, connection)
-        end
-    catch ex
-        @error(
-            "An exception occurred while trying to send a WebIO message to a "
-                * "frontend:",
-            exception=ex,
-        )
-        delete!(pool.connections, connection)
-    finally
-        return nothing
-    end
-end


### PR DESCRIPTION
Here's a potential fix for #343. It's my best guess at how to implement the second option listed under "Solution" in that issue. 

In this implementation, each connection has its own buffer of messages and its own long-running task which exists only to take messages from the buffer and send them to the connection, potentially deleting the buffer if the connection is closed. If a scope has no connections attached, then trying to send a message to it will block until a connection is made. 

I've only done basic testing on this, but I can give it some more attention if the general approach seems reasonable. 
