### PR TITLE
Introduce hooks for new and lost connections for WebIO.Scope

### DIFF
--- a/src/scope.jl
+++ b/src/scope.jl
@@ -321,6 +321,15 @@ end
 onmount(scope::Scope, f) = onmount(scope, JSString(f))
 onimport(scope::Scope, f) = onimport(scope, JSString(f))
 
+on_open_connection(callback, scope::Scope) =
+    push!(scope.pool.open_connection_callbacks, callback)
+off_open_connection(callback, scope::Scope ) =
+    delete!(scope.pool.open_connection_callbacks, callback)
+on_close_connection(callback, scope::Scope) =
+    push!(scope.pool.close_connection_callbacks, callback)
+off_close_connection(callback, scope::Scope) =
+    delete!(scope.pool.close_connection_callbacks, callback)
+
 Base.@deprecate ondependencies(ctx, jsf) onimport(ctx, jsf)
 
 """


### PR DESCRIPTION
This is an alternative to #346 which is much less invasive to the structure of WebIO. With this change I can essentially implement a design like #346 entirely within an external package (MeshCat in this case), using my own set of channels to mediate communication with the clients or just synchronously sending to each connection. 

For example, with this PR I can define my own `Router` that implements #346 like so:

```julia
struct Router
    scope::Scope
    channels::Dict{AbstractConnection, Channel{Any}}

    function Router(scope::Scope)
        router = new(scope, Dict())
        for conn in scope.pool.connections
            _add_outbox!(router, conn)
        end
        WebIO.on_open_connection(scope) do conn
            _add_outbox!(router, conn)
        end
        WebIO.on_close_connection(scope) do conn
            delete!(router.channels, conn)
        end
        router
    end
end

function _add_outbox!(router::Router, conn::AbstractConnection)
    if !(conn in keys(router.channels))
        let outbox = Channel{Any}(Inf)
            router.channels[conn] = outbox
            @async begin
                while true
                    # Catch errors here, otherwise they are lost to the void.
                    try
                        msg = take!(outbox)
                        WebIO.send(conn, msg)
                    catch exc
                        println("Error:", exc)
                        break
                    end
                end
            end
        end
    end
end

function send(router::Router, msg)
    for channel in values(router.channels)
        put!(channel, msg)
    end
end
```

