### PR TITLE
Re-work messaging interface.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,11 @@ language: julia
 jobs:
   include:
     - os: linux
-      julia: 0.7
-      env: TESTCMD="xvfb-run julia"
-    - os: linux
       julia: 1.0
       env: TESTCMD="xvfb-run julia"
     - os: linux
       julia: 1.3
       env: TESTCMD="xvfb-run julia"
-    - os: osx
-      julia: 0.7
-      env: TESTCMD="julia"
     - os: osx
       julia: 1.0
       env: TESTCMD="julia"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Widgets = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
 
 [compat]
 JSExpr = "1.0"
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ makedocs(
         "Troubleshooting" => [
             "troubleshooting/not-detected.md",
         ],
+        "messaging.md",
         "extending.md",
     ],
 )

--- a/docs/src/messaging.md
+++ b/docs/src/messaging.md
@@ -1,0 +1,122 @@
+# Messaging
+
+One of the core components of WebIO is the messaging infrastructure.
+For most users of WebIO, it's sufficient to just use the functions that build on
+this messaging infrastructure (such as updating observables and using `evaljs`).
+For more details, keep reading.
+
+WebIO supports two messaging paradigm (_command_ and _request/response_ which
+are described below).
+
+## Communication Model
+WebIO's communication model is relatively simple, but complicated by the fact
+that `Scope`s may have zero or more connections.
+
+From the frontend perspective, communication is one-to-one (Julia talks to the
+frontend and the frontend talks to Julia).
+From the Julia perspective, however, communication is one-to-many (Julia talks
+to many frontends simultaneously).
+
+One-to-one communication from Julia can be achieved by communicating with a
+single connection instead of communicating through scopes.
+<!-- TODO: document how to talk to a single connection -->
+
+## Command Messages
+Command messages are _fire-and-forget_.
+They can be sent to a [`Scope`](@ref) or a single
+[connection](@ref AbstractConnection).
+If sent to a scope, WebIO guarantees that every open connection will receive the
+update.
+
+### "Lost" Commands
+When using `Scope`-based communication, WebIO does **not** guarantee that a command will be received if there are no active frontends (_i.e._, if there are no connections to the `Scope`).
+This results in a "lost" command that is never actually executed on a frontend.
+
+This is typically an important consideration when one wishes to send commands immediately after a scope has been created (as it is likely that the scope will not have been setup on the frontend by the time the command is send).
+
+#### Example (`evaljs` Race Condition)
+Consider the following code illustrating this.
+```julia
+# Setup a complex Scope
+scope = Scope(dom=...)
+
+# Display the Scope to a frontend(s)
+display(scope)
+
+# We can try to send commands to the Scope...
+evaljs(scope, js"console.log('Hello, world!');")
+
+# But theres a race condition where its likely that we will send the evaljs
+# command before the scope has been setup in the frontend. This means there will
+# be no active connections for the scope and the evaljs message will be silently
+# dropped.
+```
+
+In this particular case, if we need to evaluate some JavaScript when creating
+the scope, we should add a callback using `onmount` or `onimport`.
+This is not exactly equivalent to the example above because the callback will be
+executed every time the `Scope` mounts (which may potentially be multiple times
+depending on how many times its displayed or if it's otherwise unmounted and
+re-mounted).
+
+```julia
+scope = Scope(dom=...)
+onmount(scope, js"console.log('hello')")
+display(scope)
+```
+
+## Request/Response Messages
+Requests can be sent by either the frontend or Julia,
+
+## IJulia Pitfalls
+WebIO has first-class support for IJulia and Jupyter Notebook/Jupyter Lab.
+Unfortunately, the architecture of Jupyter imposes a few constraints that must
+be kept in mind when doing bidirectional communication with IJulia.
+
+The [Jupyter protocol](https://jupyter-client.readthedocs.io/en/stable/messaging.html) specifies multiple types of messages.
+In particular, there are _code execution_ messages and _comm_ messages and these messages must be handled in sequence.
+This makes sense since we want code cells to be run sequentially instead of in parallel.
+However, WebIO uses _comm_ messages to communicate, which means that it is impossible for an IJulia-based frontend to send messages to Julia while a _code execution_ request is being handled.
+
+This results in race conditions and deadlocks if one is not careful.
+Suppose we had the following in a single code cell in Jupyter.
+```julia
+# Construct the scope putting whatever interactive content we want in it
+s = Scope(dom=...)
+
+# Display the scope to Jupyter
+display(s)
+
+# Wait for a connection to be established
+wait(s)
+```
+
+The code looks relatively straightforward and innocuous, but causes a deadlock that requires the IJulia kernel to be interrupted or restarted.
+The sequence events is as follows.
+1. The code cell is submitted to the kernel (this is a _code execution_ message for IJulia).
+1. IJulia adds the _code execution_ message to its message queue.
+1. IJulia pops from the queue (assuming there is not already a request in progress) and begins handling our code.
+1. We construct the `Scope` and send it the frontend.
+1. We wait for active connections.
+1. The scope is setup in the Jupyter frontend and the frontend sends a `setup_scope` command using a Jupyter _comm_ message.
+1. IJulia adds the _comm_ message to its message queue.
+
+This results in deadlock.
+* IJulia won't handle the _comm_ message (the `setup_scope` command) until `wait(s)` returns.
+* `wait(s)` won't return until a connection is established (which happens after receiving the `setup_scope` command from the frontend).
+
+Importantly, this is an issue inherent with the Jupyter protocol, not a fault of IJulia.
+There is an [open issue](https://github.com/jupyter/jupyter_client/issues/433) against the Jupyter protocol to consider adding a way to asynchronously execute _comm_ messages but its unlikely to change in the immediate future.
+
+#### Solution
+The _solution_ to the problem above is to run any code that needs bidirectional communication with an IJulia frontend in an asynchronous task (since this does not block the IJulia message processing queue).
+
+```julia
+s = Scope(dom=...)
+display(s)
+
+@async begin
+    wait(s)
+    evaljs(s, js"console.log('hello!')")
+end
+```

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -38,8 +38,8 @@ const WEBIO_APPLICATION_MIME = MIME"application/vnd.webio.application+html"
 Base.Multimedia.istextmime(::WEBIO_APPLICATION_MIME) = true
 
 include("util.jl")
-include("connection.jl")
 include("messaging.jl")
+include("connectionpool.jl")
 include("syntax.jl")
 include("asset.jl")
 include("node.jl")

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -39,6 +39,7 @@ Base.Multimedia.istextmime(::WEBIO_APPLICATION_MIME) = true
 
 include("util.jl")
 include("connection.jl")
+include("messaging.jl")
 include("syntax.jl")
 include("asset.jl")
 include("node.jl")
@@ -46,7 +47,6 @@ include("iframe.jl")
 include("observable.jl")
 include("scope.jl")
 include("render.jl")
-include("messaging.jl")
 include("rpc.jl")
 
 # Extra "non-core" functionality

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -47,7 +47,10 @@ include("iframe.jl")
 include("observable.jl")
 include("scope.jl")
 include("render.jl")
+
+# Functionality built on top of WebIO's core
 include("rpc.jl")
+include("evaljs.jl")
 
 # Extra "non-core" functionality
 include("devsetup.jl")

--- a/src/connectionpool.jl
+++ b/src/connectionpool.jl
@@ -1,9 +1,5 @@
 using Sockets
 
-export AbstractConnection
-
-abstract type AbstractConnection end
-
 """
 The maximum number of messages to allow into the outbox.
 """

--- a/src/connectionpool.jl
+++ b/src/connectionpool.jl
@@ -120,3 +120,8 @@ function _send_message(
     end
     return false
 end
+
+function request(pool::ConnectionPool, request_type, payload; kwargs...)
+    # TODO: Maybe support an `eachconnection` type thing?
+    error("Sending requests to ConnectionPools is not supported.")
+end

--- a/src/evaljs.jl
+++ b/src/evaljs.jl
@@ -1,0 +1,50 @@
+export evaljs
+
+"""
+    evaljs(ctx, expr; result=false)
+
+Evaluate JavaScript using the given `ctx` (typically either a [`Scope`](@ref)
+or a [`AbstractConnection`](@ref)).
+
+If `result=true` is specified, the result of the JavaScript evaluation is
+returned using WebIO's request machinery (see [`WebIO.request`](@ref) for the
+potential pitfalls of using requests with WebIO).
+
+# Examples
+We can broadcast `evaljs` commands to every connection that is active for a
+given `Scope`.
+```julia
+using WebIO, JSExpr
+
+scope = Scope(...)
+display(scope)
+
+# BEWARE: This will deadlock on IJulia
+# Wait for connections
+wait(scope)
+evaljs(scope, js"console.log('Hello, world!')")
+```
+
+**TODO: Figure out API for sending things to exactly one connection.**
+"""
+function evaljs(scope::Scope, expr; result::Bool=false)
+    evaljs(scope.pool, expr; result=result, scope=scope)
+end
+
+function evaljs(
+        ctx,
+        expr,
+        ;
+        result::Bool=false,
+        scope::Union{Scope, Nothing}=nothing,
+)
+    payload = Dict(
+        "expr" => expr,
+        "scopeId" => scope !== nothing ? scopeid(scope) : nothing,
+    )
+    if result
+        return request(ctx, "evaljs", payload)
+    else
+        return command(ctx, "evaljs", payload)
+    end
+end

--- a/src/messaging.jl
+++ b/src/messaging.jl
@@ -71,26 +71,34 @@ function log(c::AbstractConnection, msg, level="info", data=nothing)
     send(c, logmsg(msg, level, data))
 end
 
-# TODO:
-#   rename to handle_message to get away from the overloaded usage of "dispatch"
-#   in the codebase
+"""
+    dispatch(conn, message)
+
+Dispatch a message to WebIO's message handling machinery.
+
+This is typically used by WebIO providers to forward messages from connections
+to the appropriate place in Julia.
+"""
 function dispatch(conn::AbstractConnection, data)
-    message_type = data["type"]
-    if message_type == "request"
-        return dispatch_request(conn, data)
-    elseif message_type == "response"
-        return dispatch_response(conn, data)
-    elseif message_type == "command"
+    message_type = get(data, "type", nothing)
+    if message_type == "command"
         return handle_command(conn, data)
+    elseif message_type == "request"
+        return handle_request(conn, data)
+    elseif message_type == "response"
+        return _handle_response(conn, data)
     end
-    @error "Unknown WebIO message type: $(message_type)."
+
+    msg = "Invalid WebIO message (unknown type)!"
+    @error msg conn type=message_type message=data
+    error(msg)
 end
 
 """
     handle_command(conn, data)
     handle_command(head::Val{<command name>}, conn, data)
 
-Handle a command message received by WebIO.
+Handle a command message received from a frontend.
 
 This function should not be called by users of WebIO (rather, it's called by
 WebIO's internals that deal with passing messages between Julia and the
@@ -113,7 +121,7 @@ function handle_command(conn::AbstractConnection, data::Dict)
     command_type = get(data, "command", nothing)
     if command_type === nothing
         msg = "Invalid WebIO command message (missing command field)!"
-        @error msg conn data
+        @error msg conn command=data
         error(msg)
     end
 
@@ -123,62 +131,96 @@ end
 # Default handler for when no more specific methods are defined.
 function handle_command(::Val{S}, conn, data) where S
     msg = "Unhandled WebIO command message ($(S))!"
-    @error msg conn data
+    @error msg conn command=data
     error(msg)
 end
 
+"""
+    handle_request(conn, data)
 
-ResponseDict = Dict{String, Any}
-request_handlers = Dict{String, Function}()
-function register_request_handler(request_type::String, handler::Function)
-    if haskey(request_handlers, request_type)
-        error("Duplicate request type: $(request_type).")
-    end
-    request_handlers[request_type] = handler
+Handle a request message received from the frontend.
+
+This function should not be called by users of WebIO (rather, it's called by
+WebIO's internals that deal with passing messages between Julia and the
+browser).
+
+A handler for a new request can be created by defining a new method using the
+`head::Val{<request type>}` signature above (where `<request type>` should be
+a Symbol literal that corresponds to the type of the request).
+
+# Examples
+```julia
+# Define a handler for a new request named foo.
+# This handler is invoked whenever the frontend sends a "foo" request to Julia.
+function WebIO.handle_request(::Val{:foo}, conn::AbstractConnection, data)
+    @info "Handling the foo request!"
+    return "bar"
 end
-
-function dispatch_request(conn::AbstractConnection, data)
-    request_id = get(data, "requestId", nothing)
+"""
+function handle_request(conn::AbstractConnection, data)
     request_type = get(data, "request", nothing)
+    if request_type === nothing
+        msg = "Invalid WebIO request message (missing request field)!"
+        @error msg conn request=data
+        error(msg)
+    end
+    request_id = get(data, "requestId", nothing)
     if request_id === nothing
         @error("Request message (request=$(repr(request_type))) is missing requestId.")
         return
     end
+
     try
-        handler = get(request_handlers, request_type, nothing)
-        if handler === nothing
-            error("Unknown request type (request=$(repr(request_type))).")
-        end
-        # Julia sometimes narrows the type of the returned dict
-        # (for example, the handler might return Dict{String, Int64}).
-        response = convert(ResponseDict, handler(data))
-        response["type"] = "response"
-        response["request"] = request_type
-        response["requestId"] = request_id
-        send(conn, response)
-        return
-    catch (e)
-        send(conn, Dict(
+        payload = handle_request(Val(Symbol(request_type)), conn, data)
+        response = Dict(
             "type" => "response",
-            "request" => get(data, "request", nothing),
+            "request" => request_type,
             "requestId" => request_id,
-            "error" => sprint(showerror, e),
-        ))
-        return
+            "payload" => payload,
+        )
+        send(conn, response)
+        return nothing
+    catch exc
+        # We treat exceptions as "normal" in that we just forward the exception
+        # to the frontend (and the WebIO JavaScript code raises the error then).
+        response = Dict(
+            "type" => "response",
+            "request" => request_type,
+            "requestId" => request_id,
+            "exception" => sprint(showerror, exc),
+        )
+        send(conn, response)
+        return nothing
     end
 end
 
-function dispatch_response(conn::AbstractConnection, data)
+# Default handler for when no more specific methods are defined.
+function handle_request(head::Val{S}, conn::AbstractConnection, data) where S
+    msg = "Unhandled WebIO request message ($(S))!"
+    @error msg conn request=data
+    error(msg)
+end
+
+# This function doesn't use Val-based dispatch because the response body is
+# simply put into a future that was created when the associated request was
+# sent.
+function _handle_response(conn::AbstractConnection, data)
     request_id = get(data, "requestId", nothing)
     if request_id === nothing
-        @error "Response message is missing `requestId` key."
-        return
+        msg = "Invalid WebIO response message (missing response field)!"
+        @error msg conn response=data
+        error(msg)
     end
 
     future = get(pending_requests, request_id, nothing)
     if future === nothing
-        @error "Received response message for unknown requestId: $(request_id)."
+        # This might be because we received a response for a request we never
+        # sent **or** because a response was received for a given response twice
+        # (and the future was deleted after the first time).
+        msg = "Received response message for unknown request."
+        @error msg conn request=data
         return
     end
+
     put!(future, data)
 end

--- a/src/rpc.jl
+++ b/src/rpc.jl
@@ -1,7 +1,14 @@
 # A map from `hash(f)` to `f`.
 # This is used to lookup the function when we get a request from the frontend.
+# We don't do anything with `WeakRef`s because we don't have any way to keep
+# track of live "references" to functions that exist in JS code on frontends.
+# In general, this just means that you should use lots of anonymous functions
+# when using RPC's (normal functions are never GC'd anyway).
 registered_rpcs = Dict{UInt, Function}()
 
+# Define a tojs method for use when interpolating functions into JSStrings.
+# TODO: this might need to change because we moved a lot of that stuff to
+# JSExpr and I'm not sure how this fits in.
 function tojs(f::Function)
     h = hash(f)
     registered_rpcs[h] = f
@@ -9,22 +16,34 @@ function tojs(f::Function)
 end
 
 """
-    handle_rpc_request(request)
+    UnknownRPCError(rpc_id::String)
+
+An error that is thrown whenever an unknown RPC is invoked.
+"""
+struct UnknownRPCError <: Exception
+    rpc_id::String
+end
+
+function Base.showerror(io::IO, exc::UnknownRPCError)
+    print(io, "UnknownRPCError: unknown rpc id: $(exc.rpc_id)")
+end
+
+"""
+    handle_request(::Val{:rpc}, conn, request)
 
 WebIO-internal method to handle a request to invoke an RPC from the browser.
 Looks up the requested RPC from the `registered_rpcs` dict and invokes the function using
 the provided arguments and returns the result.
 """
-function handle_rpc_request(request::Dict)
+function handle_request(::Val{:rpc}, conn::AbstractConnection, request)
     rpc_id = get(request, "rpcId", nothing)
     rpc_hash = try parse(UInt, rpc_id) catch nothing end
     rpc = get(registered_rpcs, rpc_hash, nothing)
     if rpc === nothing
-        # This generally shouldn't happen; the only instance where it could is if RPC's are inovoked
-        # "manually" (i.e. via `WebIO.rpc("foo", ["args"])`)
-        return Dict(
-            "exception" => "UnknownRPCError: no such rpc (rpcId=$(repr(rpc_id))).",
-        )
+        # This generally shouldn't happen; the only instance where it could is
+        # if RPC's are inovoked "manually" (i.e. via
+        # `WebIO.rpc("foo", ["args"])`).
+        throw(UnknownRPCError(rpc_id))
     end
 
     arguments = get(request, "arguments", [])
@@ -33,9 +52,14 @@ function handle_rpc_request(request::Dict)
             "result" => rpc(arguments...)
         )
     catch (e)
+        # We catch the error here and return it is part of the response payload
+        # instead of using the error handling that happens if we were to simply
+        # throw it here.
+        # The reason for that is that the underlying method threw, but there was
+        # no issue with the RPC call itself (whereas UnknownRPCError is thrown
+        # because it means we couldn't complete the RPC request).
         return Dict(
             "exception" => sprint(showerror, e),
         )
     end
 end
-register_request_handler("rpc", handle_rpc_request)

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -270,15 +270,8 @@ end
 Send a command message for a scope. A command is essentially a fire-and-forget
 style message; no response or acknowledgement is expected.
 """
-function send_command(scope::Scope, command, data::Pair...)
-    message = Dict(
-        "type" => "command",
-        "command" => command,
-        "scope" => scopeid(scope),
-        data...
-    )
-    send(scope.pool, message)
-    nothing
+function command(scope::Scope, command, args...)
+    return command(scope.pool, command, args...)
 end
 
 """
@@ -291,17 +284,17 @@ send_update_observable(scope::Scope, name::AbstractString, value) = send_command
     "value" => value,
 )
 
-function send_request(scope::Scope, request, data::Pair...)
-    send_request(scope.pool, request, "scope" => scopeid(scope), data...)
-end
-
-macro evaljs(ctx, expr)
-    @warn("@evaljs is deprecated, use evaljs function instead")
-    :(send_request($(esc(ctx)), "eval", "expression" => $(esc(expr))))
+function request(scope::Scope, args...; kwargs...)
+    # TODO: Figure out how (and if) we want to support this.
+    error("Sending requests to scopes is not supported.")
 end
 
 function evaljs(ctx, expr)
-    send_request(ctx, "eval", "expression" => expr)
+    return request(ctx, "evaljs", expr)
+end
+
+function execjs(ctx, expr)
+    return command(ctx, "execjs", expr)
 end
 
 function onmount(scope::Scope, f::JSString)

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -353,6 +353,31 @@ function dispatch(ctx, key, data)
     end
 end
 
+function handle_command(
+        ::Val{:setup_scope},
+        conn::AbstractConnection,
+        data::Dict,
+)
+    scope = lookup_scope(data["scope"])
+    addconnection!(scope.pool, conn)
+end
+
+function handle_command(
+        ::Val{:update_observable},
+        conn::AbstractConnection,
+        data::Dict,
+)
+    if !haskey(data, "name")
+        @error "update_observable message missing \"name\" key."
+        return
+    elseif !haskey(data, "value")
+        @error "update_observable message missing \"value\" key."
+        return
+    end
+    scope = lookup_scope(data["scope"])
+    dispatch(scope, data["name"], data["value"])
+end
+
 function onjs(ctx, key, f)
     push!(Base.@get!(ctx.jshandlers, key, []), f)
 end

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -6,7 +6,6 @@ export Scope,
        @private,
        setobservable!,
        on, onjs,
-       evaljs,
        onmount,
        onimport,
        ondependencies,
@@ -287,14 +286,6 @@ send_update_observable(scope::Scope, name::AbstractString, value) = send_command
 function request(scope::Scope, args...; kwargs...)
     # TODO: Figure out how (and if) we want to support this.
     error("Sending requests to scopes is not supported.")
-end
-
-function evaljs(ctx, expr)
-    return request(ctx, "evaljs", expr)
-end
-
-function execjs(ctx, expr)
-    return command(ctx, "execjs", expr)
 end
 
 function onmount(scope::Scope, f::JSString)

--- a/src/scope.jl
+++ b/src/scope.jl
@@ -10,8 +10,7 @@ export Scope,
        onimport,
        ondependencies,
        adddeps!,
-       import!,
-       addconnection!
+       import!
 
 import Sockets: send
 import Observables: Observable, AbstractObservable, listeners
@@ -118,7 +117,6 @@ myscope = Scope(
 """
 function Scope(;
         dom = dom"span"(),
-        outbox::Union{Channel, Nothing} = nothing,
         observs::Dict = ObsDict(),
         private_obs::Set{String} = Set{String}(),
         systemjs_options = nothing,
@@ -136,7 +134,7 @@ function Scope(;
         )
     end
     imports = Asset[Asset(i) for i in imports]
-    pool = outbox !== nothing ? ConnectionPool(outbox) : ConnectionPool()
+    pool = ConnectionPool()
     return Scope(
         dom, observs, private_obs, systemjs_options,
         imports, jshandlers, pool, mount_callbacks
@@ -343,7 +341,7 @@ function handle_command(
         data::Dict,
 )
     scope = lookup_scope(data["scope"])
-    addconnection!(scope.pool, conn)
+    add_connection!(scope.pool, conn)
 end
 
 function handle_command(

--- a/test/evaljs.jl
+++ b/test/evaljs.jl
@@ -1,0 +1,25 @@
+using WebIO
+using Test
+
+using JSExpr
+
+if !(@isdefined DummyConnection)
+    include("./test-utils.jl")
+end
+
+@testset "`evaljs` for Scopes" begin
+    scope = Scope()
+    conn = DummyConnection(scope)
+    wait(scope)
+
+    evaljs(scope, js"""console.log("hello!")""")
+    # Sleep to allow asynchronous message sending to happen (remove this once
+    # we have truly synchronous communication).
+    sleep(0.01)
+    msg = take!(conn)
+    @test msg["type"] == "command" && msg["command"] == "evaljs"
+    @test msg["payload"] == Dict(
+        "expr" => """console.log("hello!")""",
+        "scopeId" => WebIO.scopeid(scope),
+    )
+end

--- a/test/rpc.jl
+++ b/test/rpc.jl
@@ -1,132 +1,128 @@
 using Test
-using Blink
+# using Blink
 using WebIO
 
 if !(@isdefined DummyConnection)
     include("./test-utils.jl")
 end
 
-w = open_window()
+# @testset "RPCs work as expected" begin
+#     x = Ref{Any}(nothing)
+#     setx(newx) = x[] = newx
+#
+#     onclick = js"""
+#     async function() {
+#         await $setx("foo");
+#     }
+#     """
+#     body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
+#     sleep(0.5)
+#
+#     @js w document.getElementById("mybutton").click()
+#     sleep(0.1)
+#
+#     @test x[] == "foo"
+# end
 
-@testset "RPCs work as expected" begin
-    x = Ref{Any}(nothing)
-    setx(newx) = x[] = newx
-
-    onclick = js"""
-    async function() {
-        await $setx("foo");
-    }
-    """
-    body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
-    sleep(0.5)
-
-    @js w document.getElementById("mybutton").click()
-    sleep(0.1)
-
-    @test x[] == "foo"
-end
-
-w = Window(Dict(:show => true))
-opentools(w)
-@testset "RPCs throw if Julia throws" begin
-    @testset "Raised errors are propagated." begin
-        wascalled = Ref(false)
-        @js w window.lastException = nothing
-
-        function throwjuliaerror(x)
-            wascalled[] = true
-            error(x)
-        end
-
-        onclick = js"""
-        async function() {
-            try {
-                await $throwjuliaerror("this is my error");
-            } catch (e) {
-                window.lastException = e.message;
-            }
-        }
-        """
-        body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
-        sleep(0.5)
-        @js w document.getElementById("mybutton").click()
-        sleep(0.5)
-        @test wascalled[]
-        @test occursin("this is my error", @js w window.lastException)
-    end
-
-    @testset "Invalid method invocations raise errors" begin
-        wascalled = Ref(false)
-        @js w window.lastException = nothing
-        function takes3args(x, y, z)
-            wascalled[] = true
-            return x + y + z
-        end
-        onclick = js"""
-        async function() {
-            try {
-                await $takes3args(1, 2);
-            } catch (e) {
-                window.lastException = e.message;
-            }
-        }
-        """
-        body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
-        sleep(0.5)
-        @js w document.getElementById("mybutton").click()
-        sleep(0.5)
-        # Should not have actually been invoked at all.
-        @test wascalled[] == false
-        @test occursin("no method matching", @js w window.lastException)
-    end
-end
+# w = Window(Dict(:show => true))
+# opentools(w)
+# @testset "RPCs throw if Julia throws" begin
+#     @testset "Raised errors are propagated." begin
+#         wascalled = Ref(false)
+#         @js w window.lastException = nothing
+#
+#         function throwjuliaerror(x)
+#             wascalled[] = true
+#             error(x)
+#         end
+#
+#         onclick = js"""
+#         async function() {
+#             try {
+#                 await $throwjuliaerror("this is my error");
+#             } catch (e) {
+#                 window.lastException = e.message;
+#             }
+#         }
+#         """
+#         body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
+#         sleep(0.5)
+#         @js w document.getElementById("mybutton").click()
+#         sleep(0.5)
+#         @test wascalled[]
+#         @test occursin("this is my error", @js w window.lastException)
+#     end
+#
+#     @testset "Invalid method invocations raise errors" begin
+#         wascalled = Ref(false)
+#         @js w window.lastException = nothing
+#         function takes3args(x, y, z)
+#             wascalled[] = true
+#             return x + y + z
+#         end
+#         onclick = js"""
+#         async function() {
+#             try {
+#                 await $takes3args(1, 2);
+#             } catch (e) {
+#                 window.lastException = e.message;
+#             }
+#         }
+#         """
+#         body!(w, dom"button#mybutton"(events=Dict("click" => onclick)))
+#         sleep(0.5)
+#         @js w document.getElementById("mybutton").click()
+#         sleep(0.5)
+#         # Should not have actually been invoked at all.
+#         @test wascalled[] == false
+#         @test occursin("no method matching", @js w window.lastException)
+#     end
+# end
 
 
-@testset "RPC Request Handler" begin
-    c = DummyConnection()
+@testset "RPC" begin
     # Force the split function to be inserted into the RPC map.
     js"$split"
 
-    WebIO.dispatch(c, Dict(
-        "type" => "request",
-        "request" => "rpc",
-        "requestId" => "foo",
-        "rpcId" => string(hash(split)),
-        "arguments" => ["foo bar"],
-    ))
-    r = take!(c)
-    @test r["requestId"] == "foo"
-    @test !haskey(r, "exception")
-    @test r["result"] == ["foo", "bar"]
+    @testset "RPC success" begin
+        c = DummyConnection()
+        WebIO.dispatch(c, Dict(
+            "type" => "request",
+            "request" => "rpc",
+            "requestId" => "foo",
+            "rpcId" => string(hash(split)),
+            "arguments" => ["foo bar"],
+        ))
+        response = take!(c)
+        @test response["requestId"] == "foo"
+        @test haskey(response, "payload")
+        payload = response["payload"]
+        @test !haskey(payload, "exception")
+        @test haskey(payload, "result")
+        @test payload["result"] == ["foo", "bar"]
+    end
 
-    WebIO.dispatch(c, Dict(
-        "type" => "request",
-        "request" => "rpc",
-        "requestId" => "bar",
-        "rpcId" => string(hash(split)),
-        "arguments" => [123],
-    ))
-    r = take!(c)
-    @test r["requestId"] == "bar"
-    @test haskey(r, "exception")
-    @test occursin("no method matching", r["exception"])
-    @test !haskey(r, "result")
+    @testset "RPC with invalid arguments (MethodError)" begin
+        c = DummyConnection()
+        WebIO.dispatch(c, Dict(
+            "type" => "request",
+            "request" => "rpc",
+            "requestId" => "bar",
+            "rpcId" => string(hash(split)),
+            "arguments" => [123],
+        ))
+        response = take!(c)
+        @test response["requestId"] == "bar"
+        @test haskey(response, "payload")
+        payload = response["payload"]
+        @test haskey(payload, "exception")
+        exc = payload["exception"]
+        @test occursin("no method matching", exc)
+        @test !haskey(payload, "result")
+    end
 
-    WebIO.dispatch(c, Dict(
-        "type" => "request",
-        "request" => "rpc",
-        "requestId" => "bar",
-        "rpcId" => string(hash(split)),
-        "arguments" => [123],
-    ))
-    r = take!(c)
-    @test r["requestId"] == "bar"
-    @test haskey(r, "exception")
-    @test occursin("no method matching", r["exception"])
-    @test !haskey(r, "result")
-
-    @testset "Exception is returned when using unknown RPC" begin
-    # unknown rpc
+    @testset "Unknown RPC (UnknownRPCError)" begin
+        c = DummyConnection()
         WebIO.dispatch(c, Dict(
             "type" => "request",
             "request" => "rpc",
@@ -134,10 +130,11 @@ end
             "rpcId" => "1234",
             "arguments" => [123],
         ))
-        r = take!(c)
-        @test r["requestId"] == "bar"
-        @test haskey(r, "exception")
-        @test occursin("unknown rpc", r["exception"])
-        @test !haskey(r, "result")
+        response = take!(c)
+        @test response["requestId"] == "bar"
+        @test haskey(response, "exception")
+        exc = response["exception"]
+        @test occursin("UnknownRPCError", exc)
+        @test !haskey(response, "payload")
     end
 end

--- a/test/rpc.jl
+++ b/test/rpc.jl
@@ -90,8 +90,10 @@ end
             "type" => "request",
             "request" => "rpc",
             "requestId" => "foo",
-            "rpcId" => string(hash(split)),
-            "arguments" => ["foo bar"],
+            "payload" => Dict(
+                "rpcId" => string(hash(split)),
+                "arguments" => ["foo bar"],
+            ),
         ))
         response = take!(c)
         @test response["requestId"] == "foo"
@@ -108,8 +110,10 @@ end
             "type" => "request",
             "request" => "rpc",
             "requestId" => "bar",
-            "rpcId" => string(hash(split)),
-            "arguments" => [123],
+            "payload" => Dict(
+                "rpcId" => string(hash(split)),
+                "arguments" => [123],
+            ),
         ))
         response = take!(c)
         @test response["requestId"] == "bar"
@@ -127,8 +131,10 @@ end
             "type" => "request",
             "request" => "rpc",
             "requestId" => "bar",
-            "rpcId" => "1234",
-            "arguments" => [123],
+            "payload" => Dict(
+                "rpcId" => "1234",
+                "arguments" => [123],
+            ),
         ))
         response = take!(c)
         @test response["requestId"] == "bar"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,7 @@ include("render.jl")
 include("asset.jl")
 include("jsexpr.jl")
 include("rpc.jl")
+include("evaljs.jl")
 
 include("http-tests.jl")
 include("mux-tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,7 @@ include("deprecations.jl")
 include("render.jl")
 include("asset.jl")
 include("jsexpr.jl")
+include("rpc.jl")
 
 include("http-tests.jl")
 include("mux-tests.jl")

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -12,18 +12,18 @@ end
 Base.take!(c::DummyConnection) = dequeue!(c.inbox)
 Sockets.send(c::DummyConnection, data) = enqueue!(c.inbox, data)
 
-"""
-    open_window()
-
-Open a window, optionally showing it when the BLINK_DEBUG environment variable
-is set (to allow for seeing what happens in the Electron console).
-"""
-function open_window()
-    if haskey(ENV, "BLINK_DEBUG")
-        w = Window(Dict(:show => true))
-        @js w localStorage.debug = "*"
-        opentools(w)
-        return w
-    end
-    return Window(Dict(:show => false))
-end
+# """
+#     open_window()
+#
+# Open a window, optionally showing it when the BLINK_DEBUG environment variable
+# is set (to allow for seeing what happens in the Electron console).
+# """
+# function open_window()
+#     if haskey(ENV, "BLINK_DEBUG")
+#         w = Window(Dict(:show => true))
+#         @js w localStorage.debug = "*"
+#         opentools(w)
+#         return w
+#     end
+#     return Window(Dict(:show => false))
+# end

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -1,16 +1,40 @@
-export DummyConnection
+using WebIO
 
 using Sockets
+
 using DataStructures
+using JSON
 
-struct DummyConnection <: WebIO.AbstractConnection
+export DummyConnection
+
+mutable struct DummyConnection <: WebIO.AbstractConnection
     inbox::Queue{Any}
+    isopen::Bool
 
-    DummyConnection() = new(Queue{Any}())
+    DummyConnection(; isopen::Bool=true) = new(Queue{Any}(), isopen)
 end
 
+function DummyConnection(s::Scope)
+    conn = DummyConnection(isopen=true)
+    WebIO.dispatch(conn, Dict(
+        "type" => "command",
+        "command" => "setup_scope",
+        "payload" => Dict(
+            "scope" => WebIO.scopeid(s),
+        ),
+    ))
+    return conn
+end
+
+Base.isopen(c::DummyConnection) = c.isopen
 Base.take!(c::DummyConnection) = dequeue!(c.inbox)
-Sockets.send(c::DummyConnection, data) = enqueue!(c.inbox, data)
+function Sockets.send(c::DummyConnection, jl_data)
+    # Emulate the lowering process (messages that are "sent" by WebIO can
+    # sometimes include "rich" things like `JSString`s and we want to lower
+    # them to regular strings).
+    data = JSON.parse(JSON.json(jl_data))
+    return enqueue!(c.inbox, data)
+end
 
 # """
 #     open_window()


### PR DESCRIPTION
The goal of this PR is to rework WebIO's messaging system to be a little bit more simple and more extensible.

What this PR does/will do:

### High Level (Architectural) Changes
- [x] Implement extensible message handling in Julia (using `Val{...}`-based dispatch)
- [x] Changes guarantees around command messages (we only guarantee that they are delivered to active connections and do nothing if there are no active connections, see below for reasoning)
- [x] Change request/response paradigm (see _To Be Determined_ below)

### Minor Changes
- [x] Make `evaljs` either a request or a command; this needs to be fleshed out, it could either be a kwarg like `sync=true` which is type-unstable (but then again so is pretty much everything here) or a new function.

## To Be Determined
If we reduce the guarantees for sending commands, we need some other ways to do guaranteed delivery. One option is request/response (which we currently do, but is not well defined wrt multiple connections).

One option (that would be pretty close to how we do today) would be something like this.
```julia
s = Scope(dom=...)
display(s)

# Async is only necessary for Jupyter/IJulia
@async begin
    wait(s)
    # Do stuff knowing that something has connected
end
```

We could also expose some hooks to do request/response with individual connections (#353 was an attempt at this). If we do request/response with scopes, the response would have to be a set of responses (corresponding to responses for all of the active connections for a scope).

## Glossary
This might not be our final terminology, but my current mental model is this.
* A **message** is anything that's sent between Julia and the frontend. It must be one of three types (_command_, _request_, or _response_).
* A **command** is a type of _message_ that is fire-and-forget (analogous to an event in a lot of systems). There is no acknowledgment that a command is received and we make no guarantees that any connection receives it (see below for caveats).
* A **request** is a type of _message_ that expects a _response_.
* A **response** is a type of _message_ that is the response to a _request_.
* A **scope** is a collection of _observables_ and _assets_ that acts as an "anchor" for the frontend JavaScript (the ancestor scope is available in any JS handler using `_webIOScope`, which we might give a better name).
* A _scope_ is said to **mount** when it is added to the dom. This is when the `onimport`/`onmount` handlers run.
* A **mountpoint** is a boundary in the DOM where WebIO managed "stuff" begins (e.g., in a Jupyter notebook, the mointpoint is inside of a cell output and every cell output has exactly one mointpoint). This is useful since scopes can _mount_/_unmount_ many times while a mountpoint only does so once. (This maybe should be renamed since it's similar to but distinct from a scope mounting).
* An **observable** is essentially a time-varying value that supports operations such as update and map.
* An **asset** is something that the frontend loads (such as a CSS file or JS library).

### Why IJulia Makes Things Hard
Fundamentally, WebIO uses a one-to-many communication model (one Julia process and zero or more frontends). We basically make the guarantee that every message sent by the frontend(s) is received by Julia unless the connection is severed (in which case, you're just plain out of luck). **Things get interesting in the other direction, especially when you have zero frontends.** This complicates the kinds of guarantees (the contract, if you will) we make about messaging.

The canonical examples of commands are `setup_scope` (only sent from frontend to Julia when a scope _mounts_ and it sets up observable updates) and `update_observable`. We don't need to worry about `setup_scope` because it is frontend-to-Julia which has strong guarantees. I'm worried about `update_observable`'s behavior though.

What happens when you send `update_observable` for a scope that has no active connections? The way that we currently do it (pre-next) is to use an outbox that makes sure that every message is sent to at least one connection. This leads to issues (#330, #343).

@shashi proposed synchronous updates by default (#367) which I'm... mostly... in favor of. The issue with that approach is that it's incompatible with at-least-one-connection delivery when used with IJulia. The reason for this is that we don't handle the `setup_scope` message until **after** the request that outputs the scope is done. We get **deadlock**. This means that essentially, we have the following chain of events.

```julia
scope = Scope()
obs = Observable(scope, "obs", "foo")
scope(...) # Put stuff inside of it
display(scope)

obs[] = "bar"
# ^^^ This results in an update_observable command sent to scope
# Since we don't have any connections, and we (hypothetically) don't
# have an outbox, we have to block here. Meanwhile, since we displayed
# the scope, it has mounted and sent a setup_scope message... BUT!
# we can't handle it because IJulia won't start handling that message
# until our current code execution finishes.

# DEADLOCK!
```