### PR TITLE
Update blink-test.jl to use preferred macro

### DIFF
--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -139,7 +139,7 @@ function WebIO.render(::ExampleRenderableType)
     node(:div, "hello world")
 end
 
-WebIO.register_renderable(ExampleRenderableType)
+@WebIO.register_renderable ExampleRenderableType
 
 w = open_window()
 @testset "register_renderable" begin


### PR DESCRIPTION
Issue #375: This change resolves a warning that was being thrown during test execution