### PR TITLE
Make WebIO statically compilable (relocatable): don't run `include()`s in __init__

### DIFF
--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -87,15 +87,21 @@ function setup(provider::Symbol)
 end
 setup(provider::AbstractString) = setup(Symbol(provider))
 
-code_mux          = read(joinpath(@__DIR__, "providers", "mux.jl"), String)
-code_blink        = read(joinpath(@__DIR__, "providers", "blink.jl"), String)
-code_ijulia       = read(joinpath(@__DIR__, "providers", "ijulia.jl"), String)
-code_generic_http = read(joinpath(@__DIR__, "providers", "generic_http.jl"), String)
+function prefetch_provider_file(basename)
+  filepath = joinpath(@__DIR__, "providers", basename)
+  code = read(filepath, String)
+  (file = filepath, code = code)
+end
+
+provider_mux          = prefetch_provider_file("mux.jl")
+provider_blink        = prefetch_provider_file("blink.jl")
+provider_ijulia       = prefetch_provider_file("ijulia.jl")
+provider_generic_http = prefetch_provider_file("generic_http.jl")
 
 function __init__()
     push!(Observables.addhandler_callbacks, WebIO.setup_comm)
     @require Mux="a975b10e-0019-58db-a62f-e48ff68538c9" begin
-        eval(code_mux)
+        include_string(@__MODULE__, provider_mux.code, provider_mux.file)
     end
     @require Blink="ad839575-38b3-5650-b840-f874b8c74a25" begin
         # The latest version of Blink defines their own WebIO integration
@@ -107,13 +113,13 @@ function __init__()
             "Please upgrade Blink for a smoother integration with WebIO.",
             :webio_blink_upgrade,
         )
-        eval(code_blink)
+        include_string(@__MODULE__, provider_blink.code, provider_blink.file)
     end
     @require IJulia="7073ff75-c697-5162-941a-fcdaad2a7d2a" begin
-        eval(code_ijulia)
+        include_string(@__MODULE__, provider_ijulia.code, provider_ijulia.file)
     end
     @require WebSockets="104b5d7c-a370-577a-8038-80a2059c5097" begin
-        eval(code_generic_http)
+        include_string(@__MODULE__, provider_generic_http.code, provider_generic_http.file)
     end
 
 end

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -93,9 +93,9 @@ function prefetch_provider_file(basename)
   (file = filepath, code = code)
 end
 
-provider_mux          = prefetch_provider_file("mux.jl")
-provider_blink        = prefetch_provider_file("blink.jl")
-provider_ijulia       = prefetch_provider_file("ijulia.jl")
+provider_mux = prefetch_provider_file("mux.jl")
+provider_blink = prefetch_provider_file("blink.jl")
+provider_ijulia = prefetch_provider_file("ijulia.jl")
 provider_generic_http = prefetch_provider_file("generic_http.jl")
 
 function __init__()

--- a/src/WebIO.jl
+++ b/src/WebIO.jl
@@ -87,10 +87,15 @@ function setup(provider::Symbol)
 end
 setup(provider::AbstractString) = setup(Symbol(provider))
 
+code_mux          = read(joinpath(@__DIR__, "providers", "mux.jl"), String)
+code_blink        = read(joinpath(@__DIR__, "providers", "blink.jl"), String)
+code_ijulia       = read(joinpath(@__DIR__, "providers", "ijulia.jl"), String)
+code_generic_http = read(joinpath(@__DIR__, "providers", "generic_http.jl"), String)
+
 function __init__()
     push!(Observables.addhandler_callbacks, WebIO.setup_comm)
     @require Mux="a975b10e-0019-58db-a62f-e48ff68538c9" begin
-        include(joinpath("providers", "mux.jl"))
+        eval(code_mux)
     end
     @require Blink="ad839575-38b3-5650-b840-f874b8c74a25" begin
         # The latest version of Blink defines their own WebIO integration
@@ -102,13 +107,13 @@ function __init__()
             "Please upgrade Blink for a smoother integration with WebIO.",
             :webio_blink_upgrade,
         )
-        include(joinpath("providers", "blink.jl"))
+        eval(code_blink)
     end
     @require IJulia="7073ff75-c697-5162-941a-fcdaad2a7d2a" begin
-        include(joinpath("providers", "ijulia.jl"))
+        eval(code_ijulia)
     end
     @require WebSockets="104b5d7c-a370-577a-8038-80a2059c5097" begin
-        include(joinpath("providers", "generic_http.jl"))
+        eval(code_generic_http)
     end
 
 end


### PR DESCRIPTION
If you statically compile an application that uses WebIO, it will attempt to run this Module __init__ at runtime, but of course those source files will no longer be present once the application has been downloaded to a user's computer.

Please see these sections from the PackageCompilerX for an overview of relocatability:
- https://kristofferc.github.io/PackageCompilerX.jl/dev/apps/#Relocatability-1
- https://kristofferc.github.io/PackageCompilerX.jl/dev/devdocs/relocatable_part_3/

(I made this code change months ago but never sent it for review, so i don't remember what the errors were. But rereading the diff, it seems reasonable. I'll rebase and update it now..)