### PR TITLE
Remove `@info` output

### DIFF
--- a/src/connection.jl
+++ b/src/connection.jl
@@ -114,7 +114,6 @@ function send_message(
         if isopen(connection)
             send(connection, msg)
         else
-            @info "Connection is not open." connection
             delete!(pool.connections, connection)
         end
     catch ex


### PR DESCRIPTION
As discussed with @travigd this message keeps popping up randomly and seems to make Juno overall more laggy (in particular in combination with `TableView`) so this is the nuclear option - NB I don't really know what the function does overall so this might well be a bad idea!