### PR TITLE
Show exception with stack trace on send_message error

### DIFF
--- a/src/connection.jl
+++ b/src/connection.jl
@@ -117,12 +117,10 @@ function send_message(
             delete!(pool.connections, connection)
         end
     catch ex
-        showerror(stderr, ex, stacktrace(catch_backtrace()))
-        println(stderr)
+        trace = sprint(showerror, ex, stacktrace(catch_backtrace()))
         @error(
             "An exception occurred while trying to send a WebIO message to a "
-                * "frontend:",
-            exception=ex,
+                * "frontend:\n$trace"
         )
         delete!(pool.connections, connection)
     finally

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -117,10 +117,10 @@ function send_message(
             delete!(pool.connections, connection)
         end
     catch ex
-        trace = sprint(showerror, ex, stacktrace(catch_backtrace()))
         @error(
             "An exception occurred while trying to send a WebIO message to a "
-                * "frontend:\n$trace"
+                * "frontend:",
+            exception = (ex, catch_backtrace())
         )
         delete!(pool.connections, connection)
     finally

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -117,6 +117,8 @@ function send_message(
             delete!(pool.connections, connection)
         end
     catch ex
+        showerror(stderr, ex, stacktrace(catch_backtrace()))
+        println(stderr)
         @error(
             "An exception occurred while trying to send a WebIO message to a "
                 * "frontend:",


### PR DESCRIPTION
Helps with JuliaGizmos/Interact.jl#290.
It doesn't solve that issue yet, since errors are still swallowed if produced in the initial position of the `@manipulate` slider.