### PR TITLE
Fix getMuxWSUrl for location.pathname other than "/"

### DIFF
--- a/packages/mux-provider/src/mux.ts
+++ b/packages/mux-provider/src/mux.ts
@@ -9,8 +9,7 @@ import WebIO from "@webio/webio";
 export const getMuxWSUrl = (): string => {
   const {protocol, host, pathname} = window.location;
   const wsProtocol = protocol == "https:" ? "wss:" : "ws:";
-  const basePath = pathname[pathname.length - 1] == "/" ? pathname : pathname + "/";
-  const wsPath = basePath + "webio-socket";
+  const wsPath = "/webio-socket" + pathname;
 
   return `${wsProtocol}//${host}${wsPath}`;
 };


### PR DESCRIPTION
fixes https://github.com/JuliaGizmos/WebIO.jl/issues/382

---

Manually tested with the following:

- in `~/.julia/dev/WebIO/` :

```
pkg> test WebIO
```

this builds the JS bundles under `deps/bundles/` (and also runs the tests locally)

- in some tmp folder

```
pkg> activate .
pkg> add Interact Mux
pkg> dev WebIO
pkg> st
  [c601a237] Interact v0.10.3
  [a975b10e] Mux v0.7.1
  [0f1e0344] WebIO v0.8.13 [`~/.julia/dev/WebIO`]

julia> using WebIO, Interact, Mux
   
julia> function gui()
           but = button("click me")
           on(but) do _
               println("was clicked")
           end
           but
       end
gui (generic function with 1 method)

julia> Mux.@app app = (Mux.defaults,
                       page("/", req->gui()),
                       page("/hallo", req->gui()),
                       page("/hallo/hello", req->gui()),
                       Mux.notfound())

julia> webio_serve(app, 8000)
Task (runnable) @0x00007f359a5adae0
```

where the button works on http://localhost:8000/, http://localhost:8000/hallo and http://localhost:8000/hallo/hello

---

Please let me know if you want me to (try to) add a tests for this. Thank you!

cc @cstjean

