### PR TITLE
Pin JupyterLab version for IJulia tests

### DIFF
--- a/test/ijulia-tests.jl
+++ b/test/ijulia-tests.jl
@@ -15,7 +15,7 @@ if haskey(ENV, "CI")
     @testset "Jupyter setup" begin
         # We need conda-forge for node.
         Conda.add_channel("conda-forge")
-        Conda.add.(["jupyterlab", "nodejs"])
+        Conda.add.(["jupyterlab=1", "nodejs"])
 
         # Remove path to make sure that we can find Conda if nothing else exists.
         oldpath = ENV["PATH"]


### PR DESCRIPTION
This is a workaround for #397 which causes tests to fail, but isn't a fix in that WebIO still isn't compatible with JupyterLab v2.