### PR TITLE
Auto-install Jupyter Notebook/Lab extensions if possible

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,10 +5,14 @@ include("./jupyter.jl")
 
 download_js_bundles()
 
-# See https://github.com/JuliaGizmos/WebIO.jl/issues/314 for the rational behind
-# why we're not installing Jupyter packages by default anymore.
-@warn(
-    "WebIO no longer installs Jupyter extensions automatically; please run "
-    * "`WebIO.install_jupyter_notebook()` or `WebIO.install_jupyter_lab()` if "
-    * "needed."
-)
+try
+    install_jupyter_labextension(; condajl=true)
+catch exc
+    @warn "Unable to install JupyterLab extension" exception=exc
+end
+
+try
+    install_jupyter_nbextension(; condajl=true)
+catch exc
+    @warn "Unable to install Jupyter Notebook extension" exception=exc
+end

--- a/deps/jupyter.jl
+++ b/deps/jupyter.jl
@@ -133,7 +133,7 @@ function find_path_jupyter_cmd()::Cmd
 end
 
 """
-    find_jupyter_cmd([; conda=false])
+    find_jupyter_cmd([; condajl=false])
 
 Find the most likely candidate for the `jupyter` executable.
 This will locate `jupyter` by searching the `PATH` environment variable and,
@@ -227,10 +227,15 @@ This copies the nbextension code to the appropriate place and writes the
 appropriate configuration files.
 """
 function install_jupyter_nbextension(
-        jupyter::Cmd=find_jupyter_cmd();
+        jupyter=nothing;
+        condajl::Union{Bool,Nothing}=nothing,
         nbextension_flags::Cmd=`--user`,
 )
     install_jupyter_serverextension()
+
+    if jupyter === nothing
+        jupyter = find_jupyter_cmd(; condajl=condajl)
+    end
 
     # Copy the nbextension files.
     install_cmd = `$jupyter nbextension install $nbextension_flags $JUPYTER_NBEXTENSION_PATH`


### PR DESCRIPTION
This has been a rough saga with WebIO, but I think trying to automatically install the extensions is a good idea.

There are however some issues:
* The installation does not respect the active Julia project (so if the frontend/Julia are using different version of WebIO, bad things might happen)
* The installation of the notebook extension is global (whereas the JupyterLab installation is only against the Jupyter installed by Conda.jl - this is a limitation of how notebook extensions work)