### PR TITLE
Update not-detected.md

### DIFF
--- a/docs/src/troubleshooting/not-detected.md
+++ b/docs/src/troubleshooting/not-detected.md
@@ -27,7 +27,7 @@ For more information on those difficulties, read the [IJulia](@ref)
 documentation.
 
 ### Jupyter Notebook
-List all extensions by running
+List all extensions by running (in the Anaconda Prompt)
 ```sh
 jupyter nbextension list
 ```


### PR DESCRIPTION
Perhaps it would be good to direct users to run this in the Acaconda Prompt rather than in Jupyter notebook? It is not clear from reading this.

It works from the Anaconda Prompt, but running it from Jupyter notebook returns this error:
```
syntax: extra token "nbextension" after end of expression

Stacktrace:
 [1] top-level scope
   @ In[23]:1
 [2] eval
   @ .\boot.jl:360 [inlined]
 [3] include_string(mapexpr::typeof(REPL.softscope), mod::Module, code::String, filename::String)
   @ Base .\loading.jl:1116
```