### PR TITLE
Set minimum Julia version to 1.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Observables = "0.5"
 Requires = "0.4.4, 0.5, 1.0.0"
 WebSockets = "1.5.0"
 Widgets = "0.6.2"
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Blink = "ad839575-38b3-5650-b840-f874b8c74a25"


### PR DESCRIPTION
Since #497, we only support Observables.jl 0.5 and up, which only supports Julia 1.6 and up. I updated the GitHub Actions to only run tests on Julia 1.6 and up, and updated the Project.toml to drop versions that we can't test.