### PR TITLE
WebSockets 1.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "WebIO"
 uuid = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
 license = "MIT"
-version = "0.8.19"
+version = "0.8.20"
 
 [deps]
 AssetRegistry = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
@@ -26,7 +26,7 @@ JSExpr = "0.5"
 JSON = "0.18, 0.19, 0.20, 0.21"
 Observables = "0.5"
 Requires = "0.4.4, 0.5, 1.0.0"
-WebSockets = "1.5.0"
+WebSockets = "1.5.0, 1.6.0"
 Widgets = "0.6.2"
 julia = "1.6"
 


### PR DESCRIPTION
WebSockets support 1.6.0
As interface to websockets didn't change, there is no code change. 

I also run this version of WebIO against not yet released Blink (https://github.com/JuliaGizmos/Blink.jl/pull/295) and Blink tests pass. 

yes, in the PR the Blink is not actually using WebSockets, but unless WebIO moves to latest WebSockets, Blink cannot upgrade to latest HTTP