### PR TITLE
Use thread-safe conditions for connection pool

### DIFF
--- a/test/blink-tests.jl
+++ b/test/blink-tests.jl
@@ -3,10 +3,6 @@ using Blink
 using Observables
 using Test
 
-notinstalled = !AtomShell.isinstalled()
-
-notinstalled && AtomShell.install()
-
 """
 Execute function f() with a timeout of `timeout` seconds. Returns the
 result of f() or `nothing` in the case of a timeout.
@@ -146,5 +142,3 @@ w = open_window()
     body!(w, ExampleRenderableType())
     @test example_renderable_was_rendered
 end
-
-notinstalled && AtomShell.uninstall()


### PR DESCRIPTION
I implement changes similar to [Blink.jl#307](https://github.com/JuliaGizmos/Blink.jl/pull/307) to fix concurrency errors when multithreaded in Julia 1.9 and interacting with a page's DOM using Blink.

Fixes [Blink.jl#308](https://github.com/JuliaGizmos/Blink.jl/issues/308), [WebIO.jl#511](https://github.com/JuliaGizmos/WebIO.jl/issues/511), and [KoraMRI.jl#168](https://github.com/cncastillo/KomaMRI.jl/issues/168).